### PR TITLE
Serve template index page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
-from flask import Flask
+from flask import Flask, render_template
 
 app = Flask(__name__)
 
 @app.route('/')
-def hello():
-    return 'Hello, World!'
+def index():
+    return render_template("index.html")
 
 if __name__ == '__main__':
     app.run()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Schedulist</title>
+</head>
+<body>
+    <h1>Welcome to Schedulist</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- render main route with an HTML template instead of plain text
- add a basic index.html template

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5127d666483288120c78bb59a104e