### PR TITLE
Add Bootstrap styling to index page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body {
+  margin: 20px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,8 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Schedulist</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw"
+      crossorigin="anonymous"
+    >
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-    <h1>Welcome to Schedulist</h1>
+    <h1 class="text-center">Welcome to Schedulist</h1>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add minimal custom stylesheet
- load Bootstrap CDN and local styles in home page

## Testing
- `pytest`
- `python app.py` & `curl -s http://127.0.0.1:5000/`

------
https://chatgpt.com/codex/tasks/task_e_68c5149d96a08328a1609ed361772e77