### PR TITLE
feat: add basic task form and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,37 @@ automatically when the application starts. To initialize the database
 manually, run:
 
 ```bash
-flask run
+python app.py
+# or
+flask --app app run
 ```
 
 This will generate a `schedulist.db` file in the project directory with the
 required tables.
+
+If you prefer to rely on the Flask CLI's default discovery, set the
+`FLASK_APP` environment variable before running `flask run`:
+
+```bash
+export FLASK_APP=app
+flask run
+```
 
 ## Usage
 
 After installing the dependencies, the application can be started locally once the Flask app is ready:
 
 ```bash
-flask run
+python app.py
+# or
+flask --app app run
 ```
+
+To use the default `flask run` command without `--app`, make sure
+`FLASK_APP` is set as shown above.
+
+With the server running, visit `http://127.0.0.1:5000/add` to create a new
+task and view it in the matrix on the home page.
 
 Usage will expand as features are implemented.
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
-from flask import Flask, render_template
-from models import db
+from datetime import datetime
+from flask import Flask, render_template, request, redirect, url_for
+from models import db, User, Task
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///schedulist.db'
@@ -9,11 +10,42 @@ db.init_app(app)
 
 with app.app_context():
     db.create_all()
+    # Create a default user for now until authentication is implemented
+    if not User.query.first():
+        demo = User(username="demo")
+        db.session.add(demo)
+        db.session.commit()
 
 
 @app.route('/')
 def index():
-    return render_template("index.html")
+    tasks_by_quadrant = {
+        1: Task.query.filter_by(quadrant=1).all(),
+        2: Task.query.filter_by(quadrant=2).all(),
+        3: Task.query.filter_by(quadrant=3).all(),
+        4: Task.query.filter_by(quadrant=4).all(),
+    }
+    return render_template("index.html", tasks=tasks_by_quadrant)
+
+
+@app.route('/add', methods=['GET', 'POST'])
+def add_task():
+    if request.method == 'POST':
+        title = request.form['title']
+        description = request.form.get('description')
+        deadline_str = request.form.get('deadline')
+        quadrant = int(request.form['quadrant'])
+        user = User.query.first()
+
+        task = Task(title=title, description=description, quadrant=quadrant, user_id=user.id)
+        if deadline_str:
+            task.deadline = datetime.strptime(deadline_str, '%Y-%m-%d').date()
+
+        db.session.add(task)
+        db.session.commit()
+        return redirect(url_for('index'))
+
+    return render_template('add_task.html')
 
 
 if __name__ == '__main__':

--- a/models.py
+++ b/models.py
@@ -23,5 +23,7 @@ class Task(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(120), nullable=False)
     description = db.Column(db.Text, nullable=True)
+    deadline = db.Column(db.Date, nullable=True)
+    quadrant = db.Column(db.Integer, nullable=False)
     completed = db.Column(db.Boolean, default=False)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)

--- a/templates/add_task.html
+++ b/templates/add_task.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Add Task</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw" crossorigin="anonymous">
+</head>
+<body>
+    <div class="container py-4">
+        <h1 class="mb-4">Add Task</h1>
+        <form method="post">
+            <div class="mb-3">
+                <label for="title" class="form-label">Title</label>
+                <input type="text" class="form-control" id="title" name="title" required>
+            </div>
+            <div class="mb-3">
+                <label for="description" class="form-label">Description</label>
+                <textarea class="form-control" id="description" name="description"></textarea>
+            </div>
+            <div class="mb-3">
+                <label for="deadline" class="form-label">Deadline</label>
+                <input type="date" class="form-control" id="deadline" name="deadline">
+            </div>
+            <div class="mb-3">
+                <label for="quadrant" class="form-label">Quadrant</label>
+                <select class="form-select" id="quadrant" name="quadrant" required>
+                    <option value="1">Urgent &amp; Important</option>
+                    <option value="2">Not Urgent &amp; Important</option>
+                    <option value="3">Urgent &amp; Not Important</option>
+                    <option value="4">Not Urgent &amp; Not Important</option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Add Task</button>
+            <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+        </form>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,72 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-    <h1 class="text-center">Welcome to Schedulist</h1>
+    <div class="container py-4">
+        <h1 class="text-center mb-4">Welcome to Schedulist</h1>
+        <div class="text-center mb-4">
+            <a href="{{ url_for('add_task') }}" class="btn btn-success">Add Task</a>
+        </div>
+
+        <!-- Eisenhower Matrix Grid -->
+        <div class="row g-4">
+            <div class="col-md-6">
+                <div class="card h-100">
+                    <div class="card-header bg-danger text-white">Urgent &amp; Important</div>
+                    <div class="card-body">
+                        {% for task in tasks[1] %}
+                            <div>{{ task.title }}</div>
+                        {% else %}
+                            <p class="text-muted">No tasks</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card h-100">
+                    <div class="card-header bg-warning text-dark">Not Urgent &amp; Important</div>
+                    <div class="card-body">
+                        {% for task in tasks[2] %}
+                            <div>{{ task.title }}</div>
+                        {% else %}
+                            <p class="text-muted">No tasks</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row g-4 mt-1">
+            <div class="col-md-6">
+                <div class="card h-100">
+                    <div class="card-header bg-primary text-white">Urgent &amp; Not Important</div>
+                    <div class="card-body">
+                        {% for task in tasks[3] %}
+                            <div>{{ task.title }}</div>
+                        {% else %}
+                            <p class="text-muted">No tasks</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card h-100">
+                    <div class="card-header bg-secondary text-white">Not Urgent &amp; Not Important</div>
+                    <div class="card-body">
+                        {% for task in tasks[4] %}
+                            <div>{{ task.title }}</div>
+                        {% else %}
+                            <p class="text-muted">No tasks</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3"
+      crossorigin="anonymous"
+    ></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand task model with deadline and quadrant fields
- add basic form to create tasks and display them per Eisenhower quadrant
- document add-task workflow in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c516e550d08328b0e3f349cfe76301