### PR TITLE
Guard task routes behind login

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-
 import os
+from functools import wraps
+
 from flask import Flask, render_template, request, redirect, url_for, session
 from authlib.integrations.flask_client import OAuth
-=======
-from flask import Flask, render_template, request, redirect, url_for
 
 from models import db, User, Task
 
@@ -35,52 +34,63 @@ with app.app_context():
         db.session.add(demo)
         db.session.commit()
 
+def login_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if "user_id" not in session:
+            return redirect(url_for("login"))
+        return f(*args, **kwargs)
+    return decorated_function
 
 @app.route('/')
+@login_required
 def index():
+    user_id = session["user_id"]
     tasks_by_quadrant = {
-        1: Task.query.filter_by(quadrant=1).all(),
-        2: Task.query.filter_by(quadrant=2).all(),
-        3: Task.query.filter_by(quadrant=3).all(),
-        4: Task.query.filter_by(quadrant=4).all(),
+        1: Task.query.filter_by(quadrant=1, user_id=user_id).all(),
+        2: Task.query.filter_by(quadrant=2, user_id=user_id).all(),
+        3: Task.query.filter_by(quadrant=3, user_id=user_id).all(),
+        4: Task.query.filter_by(quadrant=4, user_id=user_id).all(),
     }
 
     return render_template("index.html", tasks=tasks_by_quadrant, user=session.get("user"))
-
 
 @app.route("/login")
 def login():
     redirect_uri = url_for("authorize", _external=True)
     return google.authorize_redirect(redirect_uri)
 
-
 @app.route("/login/callback")
 def authorize():
     token = google.authorize_access_token()
     user_info = google.parse_id_token(token)
     session["user"] = user_info
-    return redirect(url_for("index"))
 
+    user = User.query.filter_by(username=user_info["email"]).first()
+    if not user:
+        user = User(username=user_info["email"])
+        db.session.add(user)
+        db.session.commit()
+
+    session["user_id"] = user.id
+    return redirect(url_for("index"))
 
 @app.route("/logout")
 def logout():
     session.pop("user", None)
+    session.pop("user_id", None)
     return redirect(url_for("index"))
-=======
-    return render_template("index.html", tasks=tasks_by_quadrant)
-
-
 
 @app.route('/add', methods=['GET', 'POST'])
+@login_required
 def add_task():
     if request.method == 'POST':
         title = request.form['title']
         description = request.form.get('description')
         deadline_str = request.form.get('deadline')
         quadrant = int(request.form['quadrant'])
-        user = User.query.first()
 
-        task = Task(title=title, description=description, quadrant=quadrant, user_id=user.id)
+        task = Task(title=title, description=description, quadrant=quadrant, user_id=session["user_id"])
         if deadline_str:
             task.deadline = datetime.strptime(deadline_str, '%Y-%m-%d').date()
 
@@ -88,8 +98,7 @@ def add_task():
         db.session.commit()
         return redirect(url_for('index'))
 
-    return render_template('add_task.html')
-
+    return render_template('add_task.html', user=session.get("user"))
 
 if __name__ == '__main__':
     app.run()

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Schedulist</title>
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw"
-      crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw"
+        crossorigin="anonymous"
     >
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
@@ -23,22 +23,11 @@
                 <a href="{{ url_for('login') }}" class="btn btn-primary">Login with Google</a>
             {% endif %}
         </div>
+
+        {% if user %}
         <div class="text-center mb-4">
             <a href="{{ url_for('add_task') }}" class="btn btn-success">Add Task</a>
         </div>
-=======
-
-        <div class="text-center mb-4">
-            <a href="{{ url_for('add_task') }}" class="btn btn-success">Add Task</a>
-        </div>
-=======
-
-        <div class="text-center mb-4">
-            <a href="{{ url_for('add_task') }}" class="btn btn-success">Add Task</a>
-        </div>
-=======
-
-
 
         <!-- Eisenhower Matrix Grid -->
         <div class="row g-4">
@@ -46,21 +35,11 @@
                 <div class="card h-100">
                     <div class="card-header bg-danger text-white">Urgent &amp; Important</div>
                     <div class="card-body">
-
-=======
-
-
                         {% for task in tasks[1] %}
                             <div>{{ task.title }}</div>
                         {% else %}
                             <p class="text-muted">No tasks</p>
                         {% endfor %}
-
-=======
-=======
-                        <!-- Tasks for Urgent & Important go here -->
-
-
                     </div>
                 </div>
             </div>
@@ -68,21 +47,11 @@
                 <div class="card h-100">
                     <div class="card-header bg-warning text-dark">Not Urgent &amp; Important</div>
                     <div class="card-body">
-
-=======
-
-
                         {% for task in tasks[2] %}
                             <div>{{ task.title }}</div>
                         {% else %}
                             <p class="text-muted">No tasks</p>
                         {% endfor %}
-
-=======
-=======
-                        <!-- Tasks for Not Urgent & Important go here -->
-
-
                     </div>
                 </div>
             </div>
@@ -93,21 +62,11 @@
                 <div class="card h-100">
                     <div class="card-header bg-primary text-white">Urgent &amp; Not Important</div>
                     <div class="card-body">
-
-=======
-
-
                         {% for task in tasks[3] %}
                             <div>{{ task.title }}</div>
                         {% else %}
                             <p class="text-muted">No tasks</p>
                         {% endfor %}
-
-=======
-=======
-                        <!-- Tasks for Urgent & Not Important go here -->
-
-
                     </div>
                 </div>
             </div>
@@ -115,35 +74,21 @@
                 <div class="card h-100">
                     <div class="card-header bg-secondary text-white">Not Urgent &amp; Not Important</div>
                     <div class="card-body">
-
-=======
-
-
                         {% for task in tasks[4] %}
                             <div>{{ task.title }}</div>
                         {% else %}
                             <p class="text-muted">No tasks</p>
                         {% endfor %}
-
-=======
-=======
-                        <!-- Tasks for Not Urgent & Not Important go here -->
-
-
-                      
-=======
-
-
                     </div>
                 </div>
             </div>
         </div>
+        {% endif %}
     </div>
-
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3"
-      crossorigin="anonymous"
+        src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3"
+        crossorigin="anonymous"
     ></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require session user for index and add routes via a reusable `login_required` decorator
- scope task queries and creation to the logged-in user
- hide task UI links when not authenticated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5dd8086188328bef5fcc7c1f3d78b