### PR TITLE
Add Google OAuth-backed user accounts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,16 +1,15 @@
 from datetime import datetime
-
 import os
+
 from flask import Flask, render_template, request, redirect, url_for, session
 from authlib.integrations.flask_client import OAuth
-=======
-from flask import Flask, render_template, request, redirect, url_for
 
 from models import db, User, Task
 
+
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///schedulist.db'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///schedulist.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 
 oauth = OAuth(app)
@@ -29,23 +28,20 @@ db.init_app(app)
 
 with app.app_context():
     db.create_all()
-    # Create a default user for now until authentication is implemented
-    if not User.query.first():
-        demo = User(username="demo")
-        db.session.add(demo)
-        db.session.commit()
 
 
-@app.route('/')
+@app.route("/")
 def index():
-    tasks_by_quadrant = {
-        1: Task.query.filter_by(quadrant=1).all(),
-        2: Task.query.filter_by(quadrant=2).all(),
-        3: Task.query.filter_by(quadrant=3).all(),
-        4: Task.query.filter_by(quadrant=4).all(),
-    }
-
-    return render_template("index.html", tasks=tasks_by_quadrant, user=session.get("user"))
+    user_id = session.get("user_id")
+    tasks_by_quadrant = {q: [] for q in range(1, 5)}
+    if user_id:
+        tasks_by_quadrant = {
+            q: Task.query.filter_by(user_id=user_id, quadrant=q).all()
+            for q in range(1, 5)
+        }
+    return render_template(
+        "index.html", tasks=tasks_by_quadrant, user=session.get("user")
+    )
 
 
 @app.route("/login")
@@ -58,38 +54,55 @@ def login():
 def authorize():
     token = google.authorize_access_token()
     user_info = google.parse_id_token(token)
+    # Look up or create user based on Google subject claim
+    user = User.query.filter_by(google_id=user_info["sub"]).first()
+    if user is None:
+        user = User(
+            username=user_info.get("email", user_info["sub"]),
+            google_id=user_info["sub"],
+        )
+        db.session.add(user)
+        db.session.commit()
     session["user"] = user_info
+    session["user_id"] = user.id
     return redirect(url_for("index"))
 
 
 @app.route("/logout")
 def logout():
     session.pop("user", None)
+    session.pop("user_id", None)
     return redirect(url_for("index"))
-=======
-    return render_template("index.html", tasks=tasks_by_quadrant)
 
 
-
-@app.route('/add', methods=['GET', 'POST'])
+@app.route("/add", methods=["GET", "POST"])
 def add_task():
-    if request.method == 'POST':
-        title = request.form['title']
-        description = request.form.get('description')
-        deadline_str = request.form.get('deadline')
-        quadrant = int(request.form['quadrant'])
-        user = User.query.first()
+    user_id = session.get("user_id")
+    if not user_id:
+        return redirect(url_for("login"))
 
-        task = Task(title=title, description=description, quadrant=quadrant, user_id=user.id)
+    if request.method == "POST":
+        title = request.form["title"]
+        description = request.form.get("description")
+        deadline_str = request.form.get("deadline")
+        quadrant = int(request.form["quadrant"])
+
+        task = Task(
+            title=title,
+            description=description,
+            quadrant=quadrant,
+            user_id=user_id,
+        )
         if deadline_str:
-            task.deadline = datetime.strptime(deadline_str, '%Y-%m-%d').date()
+            task.deadline = datetime.strptime(deadline_str, "%Y-%m-%d").date()
 
         db.session.add(task)
         db.session.commit()
-        return redirect(url_for('index'))
+        return redirect(url_for("index"))
 
-    return render_template('add_task.html')
+    return render_template("add_task.html")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run()
+

--- a/models.py
+++ b/models.py
@@ -12,6 +12,7 @@ class User(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
+    google_id = db.Column(db.String, unique=True, nullable=False)
 
     tasks = db.relationship('Task', backref='user', lazy=True)
 


### PR DESCRIPTION
## Summary
- Add `google_id` column to `User` model for OAuth mapping
- Persist and reuse users via Google `sub` in login callback
- Store logged-in user's id in session and remove demo user fallback

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5dd7f82148328bf77b02bb4149569