### PR TITLE
Protect task routes with login enforcement

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 
 import os
+from functools import wraps
 from flask import Flask, render_template, request, redirect, url_for, session
 from authlib.integrations.flask_client import OAuth
-=======
-from flask import Flask, render_template, request, redirect, url_for
 
 from models import db, User, Task
 
@@ -36,13 +35,24 @@ with app.app_context():
         db.session.commit()
 
 
+def login_required(f):
+    """Decorator to require a logged-in user."""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if "user_id" not in session:
+            return redirect(url_for("login"))
+        return f(*args, **kwargs)
+    return decorated_function
+
+
 @app.route('/')
+@login_required
 def index():
     tasks_by_quadrant = {
-        1: Task.query.filter_by(quadrant=1).all(),
-        2: Task.query.filter_by(quadrant=2).all(),
-        3: Task.query.filter_by(quadrant=3).all(),
-        4: Task.query.filter_by(quadrant=4).all(),
+        1: Task.query.filter_by(user_id=session["user_id"], quadrant=1).all(),
+        2: Task.query.filter_by(user_id=session["user_id"], quadrant=2).all(),
+        3: Task.query.filter_by(user_id=session["user_id"], quadrant=3).all(),
+        4: Task.query.filter_by(user_id=session["user_id"], quadrant=4).all(),
     }
 
     return render_template("index.html", tasks=tasks_by_quadrant, user=session.get("user"))
@@ -58,6 +68,13 @@ def login():
 def authorize():
     token = google.authorize_access_token()
     user_info = google.parse_id_token(token)
+    username = user_info.get("email")
+    user = User.query.filter_by(username=username).first()
+    if not user:
+        user = User(username=username)
+        db.session.add(user)
+        db.session.commit()
+    session["user_id"] = user.id
     session["user"] = user_info
     return redirect(url_for("index"))
 
@@ -65,22 +82,20 @@ def authorize():
 @app.route("/logout")
 def logout():
     session.pop("user", None)
+    session.pop("user_id", None)
     return redirect(url_for("index"))
-=======
-    return render_template("index.html", tasks=tasks_by_quadrant)
-
 
 
 @app.route('/add', methods=['GET', 'POST'])
+@login_required
 def add_task():
     if request.method == 'POST':
         title = request.form['title']
         description = request.form.get('description')
         deadline_str = request.form.get('deadline')
         quadrant = int(request.form['quadrant'])
-        user = User.query.first()
 
-        task = Task(title=title, description=description, quadrant=quadrant, user_id=user.id)
+        task = Task(title=title, description=description, quadrant=quadrant, user_id=session["user_id"])
         if deadline_str:
             task.deadline = datetime.strptime(deadline_str, '%Y-%m-%d').date()
 


### PR DESCRIPTION
## Summary
- Add `login_required` decorator to ensure `session['user_id']` is set before accessing task routes
- Filter task queries by logged-in user and associate new tasks with their `user_id`
- Store user ID after OAuth login and clear it on logout

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5df6db57c8328a326cc1c742c9e4c