### PR TITLE
Add task ownership checks to manipulation routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import os
 from functools import wraps
 
-from flask import Flask, render_template, request, redirect, url_for, session
+from flask import Flask, render_template, request, redirect, url_for, session, abort
 from authlib.integrations.flask_client import OAuth
 
 from models import db, User, Task
@@ -40,6 +40,14 @@ def login_required(f):
     return decorated_function
 
 
+def get_user_task_or_404(task_id: int) -> Task:
+    """Retrieve a task and ensure it belongs to the logged-in user."""
+    task = Task.query.get_or_404(task_id)
+    if task.user_id != session["user_id"]:
+        abort(404)
+    return task
+
+
 @app.route("/")
 @login_required
 def index():
@@ -55,7 +63,7 @@ def index():
 @app.route("/tasks/<int:task_id>/toggle")
 @login_required
 def toggle_task(task_id: int):
-    task = Task.query.get_or_404(task_id)
+    task = get_user_task_or_404(task_id)
     task.completed = not task.completed
     db.session.commit()
     return redirect(url_for("index"))
@@ -119,7 +127,7 @@ def add_task():
 @app.route("/task/<int:task_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit_task(task_id):
-    task = Task.query.get_or_404(task_id)
+    task = get_user_task_or_404(task_id)
     if request.method == "POST":
         task.title = request.form["title"]
         task.description = request.form.get("description")
@@ -136,7 +144,7 @@ def edit_task(task_id):
 @app.route("/task/<int:task_id>/delete", methods=["GET", "POST"])
 @login_required
 def delete_task(task_id):
-    task = Task.query.get_or_404(task_id)
+    task = get_user_task_or_404(task_id)
     if request.method == "POST":
         db.session.delete(task)
         db.session.commit()


### PR DESCRIPTION
## Summary
- ensure task routes verify user ownership
- abort if tasks accessed by another user
- centralize ownership logic in helper for future routes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5e7919b6083288ae28500cae76053