### PR TITLE
Validate email claim before user creation

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import app, db, google, User
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    """Ensure a clean database before each test."""
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    yield
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_authorize_with_email(client, monkeypatch):
+    monkeypatch.setattr(google, "authorize_access_token", lambda: {})
+    monkeypatch.setattr(
+        google,
+        "parse_id_token",
+        lambda token: {"sub": "abc123", "email": "user@example.com"},
+    )
+
+    response = client.get("/login/callback")
+    assert response.status_code == 302
+    with app.app_context():
+        user = User.query.filter_by(google_id="abc123").first()
+        assert user is not None
+        assert user.email == "user@example.com"
+
+
+def test_authorize_without_email(client, monkeypatch):
+    monkeypatch.setattr(google, "authorize_access_token", lambda: {})
+    monkeypatch.setattr(google, "parse_id_token", lambda token: {"sub": "abc123"})
+
+    response = client.get("/login/callback")
+    assert response.status_code == 400
+    assert b"Email claim missing" in response.data


### PR DESCRIPTION
## Summary
- Guard Google login user creation on presence of email claim
- Return a 400 error when email claim is missing
- Test login flows with and without email claims

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e7a0c3548328ba25ca20debd86b5