### PR TITLE
feat: configure database via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ Schedulist is a work-in-progress productivity tool designed to help organize and
 
 ## Database Setup
 
-This project uses a SQLite database. The database file is created
-automatically when the application starts. To initialize the database
-manually, run:
+The application reads its database connection string from the
+`DATABASE_URL` environment variable. Provide a PostgreSQL URL such as:
+
+```bash
+export DATABASE_URL="postgresql://user:password@localhost/schedulist"
+```
+
+If `DATABASE_URL` is not set, the app falls back to a local SQLite file
+(`schedulist.db`). To initialize the database manually, run:
 
 ```bash
 python app.py

--- a/app.py
+++ b/app.py
@@ -3,8 +3,6 @@ import os
 from functools import wraps
 
 
-from flask import Flask, render_template, request, redirect, url_for, session, abort
-=======
 from flask import (
     Flask,
     render_template,
@@ -21,7 +19,9 @@ from models import db, User, Task
 
 
 app = Flask(__name__)
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///schedulist.db"
+app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+    "DATABASE_URL", "sqlite:///schedulist.db"
+)
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 


### PR DESCRIPTION
## Summary
- load SQLAlchemy database URL from `DATABASE_URL` environment variable
- document PostgreSQL connection configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ed6a11c883289ec0ff5d05a3e120