### PR TITLE
feat: improve form layout and validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,6 @@ import os
 from functools import wraps
 
 
-from flask import Flask, render_template, request, redirect, url_for, session, abort
-=======
 from flask import (
     Flask,
     render_template,

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,11 @@
 body {
   margin: 20px;
 }
+
+.form-section {
+  margin-bottom: 1rem;
+}
+
+.form-actions {
+  margin-top: 1rem;
+}

--- a/templates/add_task.html
+++ b/templates/add_task.html
@@ -5,34 +5,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Add Task</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
     <div class="container py-4">
         <h1 class="mb-4">Add Task</h1>
-        <form method="post">
-            <div class="mb-3">
+        <form method="post" class="row g-3">
+            <div class="col-md-6 form-section">
                 <label for="title" class="form-label">Title</label>
                 <input type="text" class="form-control" id="title" name="title" required>
             </div>
-            <div class="mb-3">
+            <div class="col-md-6 form-section">
+                <label for="deadline" class="form-label">Deadline</label>
+                <input type="date" class="form-control" id="deadline" name="deadline" required min="2000-01-01" max="2099-12-31">
+            </div>
+            <div class="col-12 form-section">
                 <label for="description" class="form-label">Description</label>
                 <textarea class="form-control" id="description" name="description"></textarea>
             </div>
-            <div class="mb-3">
-                <label for="deadline" class="form-label">Deadline</label>
-                <input type="date" class="form-control" id="deadline" name="deadline">
-            </div>
-            <div class="mb-3">
+            <div class="col-md-6 form-section">
                 <label for="quadrant" class="form-label">Quadrant</label>
-                <select class="form-select" id="quadrant" name="quadrant" required>
-                    <option value="1">Urgent &amp; Important</option>
-                    <option value="2">Not Urgent &amp; Important</option>
-                    <option value="3">Urgent &amp; Not Important</option>
-                    <option value="4">Not Urgent &amp; Not Important</option>
-                </select>
+                <input type="number" class="form-control" id="quadrant" name="quadrant" required min="1" max="4">
+                <div class="form-text">1: Urgent &amp; Important, 2: Not Urgent &amp; Important, 3: Urgent &amp; Not Important, 4: Not Urgent &amp; Not Important</div>
             </div>
-            <button type="submit" class="btn btn-primary">Add Task</button>
-            <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+            <div class="col-12 form-actions">
+                <button type="submit" class="btn btn-primary">Add Task</button>
+                <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+            </div>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>

--- a/templates/delete_task.html
+++ b/templates/delete_task.html
@@ -5,14 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Delete Task</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
     <div class="container py-4">
         <h1 class="mb-4">Delete Task</h1>
         <p>Are you sure you want to delete "{{ task.title }}"?</p>
-        <form method="post">
-            <button type="submit" class="btn btn-danger">Delete</button>
-            <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+        <form method="post" class="row g-3">
+            <div class="col-12 form-actions">
+                <button type="submit" class="btn btn-danger">Delete</button>
+                <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+            </div>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>

--- a/templates/edit_task.html
+++ b/templates/edit_task.html
@@ -5,34 +5,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Edit Task</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
     <div class="container py-4">
         <h1 class="mb-4">Edit Task</h1>
-        <form method="post">
-            <div class="mb-3">
+        <form method="post" class="row g-3">
+            <div class="col-md-6 form-section">
                 <label for="title" class="form-label">Title</label>
                 <input type="text" class="form-control" id="title" name="title" value="{{ task.title }}" required>
             </div>
-            <div class="mb-3">
+            <div class="col-md-6 form-section">
+                <label for="deadline" class="form-label">Deadline</label>
+                <input type="date" class="form-control" id="deadline" name="deadline" value="{{ task.deadline.strftime('%Y-%m-%d') if task.deadline else '' }}" required min="2000-01-01" max="2099-12-31">
+            </div>
+            <div class="col-12 form-section">
                 <label for="description" class="form-label">Description</label>
                 <textarea class="form-control" id="description" name="description">{{ task.description }}</textarea>
             </div>
-            <div class="mb-3">
-                <label for="deadline" class="form-label">Deadline</label>
-                <input type="date" class="form-control" id="deadline" name="deadline" value="{{ task.deadline.strftime('%Y-%m-%d') if task.deadline else '' }}">
-            </div>
-            <div class="mb-3">
+            <div class="col-md-6 form-section">
                 <label for="quadrant" class="form-label">Quadrant</label>
-                <select class="form-select" id="quadrant" name="quadrant" required>
-                    <option value="1" {% if task.quadrant == 1 %}selected{% endif %}>Urgent &amp; Important</option>
-                    <option value="2" {% if task.quadrant == 2 %}selected{% endif %}>Not Urgent &amp; Important</option>
-                    <option value="3" {% if task.quadrant == 3 %}selected{% endif %}>Urgent &amp; Not Important</option>
-                    <option value="4" {% if task.quadrant == 4 %}selected{% endif %}>Not Urgent &amp; Not Important</option>
-                </select>
+                <input type="number" class="form-control" id="quadrant" name="quadrant" value="{{ task.quadrant }}" required min="1" max="4">
+                <div class="form-text">1: Urgent &amp; Important, 2: Not Urgent &amp; Important, 3: Urgent &amp; Not Important, 4: Not Urgent &amp; Not Important</div>
             </div>
-            <button type="submit" class="btn btn-primary">Update Task</button>
-            <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+            <div class="col-12 form-actions">
+                <button type="submit" class="btn btn-primary">Update Task</button>
+                <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+            </div>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- use Bootstrap grid and custom spacing for task forms
- add HTML5 validation attributes for task inputs
- clean up stray conflict in app imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ed675cf48328a9eab38dc9fc12e8