### PR TITLE
Add in-memory testing fixtures and task CRUD tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,6 @@ import os
 from functools import wraps
 
 
-from flask import Flask, render_template, request, redirect, url_for, session, abort
-=======
 from flask import (
     Flask,
     render_template,
@@ -38,8 +36,6 @@ google = oauth.register(
 )
 
 db.init_app(app)
-with app.app_context():
-    db.create_all()
 
 
 def login_required(f):
@@ -167,5 +163,7 @@ def delete_task(task_id):
 
 
 if __name__ == "__main__":
+    with app.app_context():
+        db.create_all()
     app.run()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import app as flask_app
+from models import db, User
+
+
+@pytest.fixture()
+def app():
+    """Create a new app instance for each test with an in-memory database."""
+    flask_app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def user(app):
+    user = User(username="user@example.com", google_id="gid", email="user@example.com")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def logged_in_client(client, user):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["user"] = {"sub": user.google_id, "email": user.email}
+    return client
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,21 +8,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from app import app, db, google, User
 
 
-@pytest.fixture(autouse=True)
-def clean_db():
-    """Ensure a clean database before each test."""
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    yield
-
-
-@pytest.fixture
-def client():
-    app.config["TESTING"] = True
-    return app.test_client()
-
-
 def test_authorize_with_email(client, monkeypatch):
     monkeypatch.setattr(google, "authorize_access_token", lambda: {})
     monkeypatch.setattr(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,71 @@
+from datetime import date
+
+import pytest
+
+from models import db, Task, User
+
+
+def test_login_required(client):
+    """The index view should redirect anonymous users to login."""
+    response = client.get("/")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_tasks_limited_to_session_user(client, app):
+    """Accessing another user's task should return 404."""
+    user1 = User(username="u1@example.com", google_id="gid1", email="u1@example.com")
+    user2 = User(username="u2@example.com", google_id="gid2", email="u2@example.com")
+    db.session.add_all([user1, user2])
+    db.session.commit()
+    task = Task(title="Test", quadrant=1, user_id=user1.id)
+    db.session.add(task)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user2.id
+
+    resp = client.get(f"/tasks/{task.id}/toggle")
+    assert resp.status_code == 404
+
+
+def test_task_crud_operations(logged_in_client, user):
+    """Create, update, toggle and delete a task for the logged in user."""
+    # Create
+    resp = logged_in_client.post(
+        "/add",
+        data={"title": "New", "quadrant": "1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    task = Task.query.filter_by(title="New", user_id=user.id).first()
+    assert task is not None
+
+    # Update
+    resp = logged_in_client.post(
+        f"/task/{task.id}/edit",
+        data={
+            "title": "Updated",
+            "description": "desc",
+            "quadrant": "2",
+            "deadline": date.today().strftime("%Y-%m-%d"),
+        },
+    )
+    assert resp.status_code == 302
+    task = Task.query.get(task.id)
+    assert task.title == "Updated"
+    assert task.quadrant == 2
+    assert task.description == "desc"
+    assert task.deadline == date.today()
+
+    # Toggle completion
+    resp = logged_in_client.get(f"/tasks/{task.id}/toggle")
+    assert resp.status_code == 302
+    task = Task.query.get(task.id)
+    assert task.completed is True
+
+    # Delete
+    resp = logged_in_client.post(f"/task/{task.id}/delete")
+    assert resp.status_code == 302
+    assert Task.query.get(task.id) is None
+


### PR DESCRIPTION
## Summary
- provide pytest fixtures that spin up an app context with an in-memory SQLite database and logged-in client helper
- add tests ensuring login is required, users cannot access others' tasks, and task CRUD flows work
- defer database creation until runtime so tests can configure the database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ed689a808328a8d7762af86929c8