### PR TITLE
Remove duplicate .env entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.env
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary
- Remove duplicate `.env` entry in `.gitignore` so `.env` is ignored only once

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6375523f88328aab67005026aea68