### PR TITLE
Add database URL example to env and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 SECRET_KEY=your_secret_key
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
+DATABASE_URL=postgresql://user:password@localhost/schedulist

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Schedulist is a work-in-progress productivity tool designed to help organize and
 1. Clone this repository.
 2. Navigate into the project directory.
 3. Copy `.env.example` to `.env` and replace the placeholder values with your
-   Google Cloud credentials.
+   Google Cloud credentials and database connection string.
 4. Install dependencies:
    ```bash
    pip install -r requirements.txt
@@ -86,6 +86,7 @@ To try logging in with Google, copy `.env.example` to `.env` and fill in:
 - `SECRET_KEY` – session secret for Flask
 - `GOOGLE_CLIENT_ID` – OAuth client ID from Google Cloud Console
 - `GOOGLE_CLIENT_SECRET` – matching client secret
+- `DATABASE_URL` – PostgreSQL connection string for the app (optional)
 
 The application loads these values automatically using [python-dotenv](https://saurabh-kumar.com/python-dotenv). After
 the file is created, navigate to `/login` to initiate the OAuth flow.


### PR DESCRIPTION
## Summary
- add `DATABASE_URL` placeholder to `.env.example`
- mention `DATABASE_URL` in installation and OAuth setup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c637563e988328b5f0005c7ca4ca18