### PR TITLE
Use dotenv for secret configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-SECRET_KEY=your-secret-key
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
+SECRET_KEY=your_secret_key
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Schedulist is a work-in-progress productivity tool designed to help organize and
 
 1. Clone this repository.
 2. Navigate into the project directory.
-3. Install dependencies (once available). For example:
+3. Copy `.env.example` to `.env` and replace the placeholder values with your
+   Google Cloud credentials.
+4. Install dependencies:
    ```bash
    pip install -r requirements.txt
+   ```
+5. Start the development server:
+   ```bash
+   flask run
    ```
 
 ## Database Setup

--- a/models.py
+++ b/models.py
@@ -1,35 +1,23 @@
 from flask_sqlalchemy import SQLAlchemy
 
-# Initialize SQLAlchemy instance
-# This will be initialized in app.py
-
 db = SQLAlchemy()
 
 
 class User(db.Model):
     """Represents a registered user."""
-    __tablename__ = 'users'
+    __tablename__ = "users"
 
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
-
     google_id = db.Column(db.String(255), unique=True, nullable=False)
-
-    email = db.Column(db.String(255), unique=True, nullable=True)
-
-
-    email = db.Column(db.String(255), unique=True, nullable=True)
-
     email = db.Column(db.String(255), unique=True, nullable=False)
 
-
-
-    tasks = db.relationship('Task', backref='user', lazy=True)
+    tasks = db.relationship("Task", backref="user", lazy=True)
 
 
 class Task(db.Model):
     """Represents a task belonging to a user."""
-    __tablename__ = 'tasks'
+    __tablename__ = "tasks"
 
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(120), nullable=False)
@@ -37,4 +25,5 @@ class Task(db.Model):
     deadline = db.Column(db.Date, nullable=True)
     quadrant = db.Column(db.Integer, nullable=False)
     completed = db.Column(db.Boolean, default=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Forbidden</title>
+<h1>Forbidden</h1>
+<p>You do not have permission to access this task.</p>

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,7 +13,7 @@ def test_login_required(client):
 
 
 def test_tasks_limited_to_session_user(client, app):
-    """Accessing another user's task should return 404."""
+    """Accessing another user's task should return 403."""
     user1 = User(username="u1@example.com", google_id="gid1", email="u1@example.com")
     user2 = User(username="u2@example.com", google_id="gid2", email="u2@example.com")
     db.session.add_all([user1, user2])
@@ -26,7 +26,7 @@ def test_tasks_limited_to_session_user(client, app):
         sess["user_id"] = user2.id
 
     resp = client.get(f"/tasks/{task.id}/toggle")
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 def test_task_crud_operations(logged_in_client, user):


### PR DESCRIPTION
## Summary
- load Flask settings from `.env` via python-dotenv
- provide example environment file and instructions
- keep `.env` out of version control
- log unauthorized task access and return 403 with a friendly error page

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `flask --app app run`


------
https://chatgpt.com/codex/tasks/task_e_68c621c4a3cc8328b3f7a156c797aaef