### PR TITLE
Use Jinja macros for quadrant card rendering

### DIFF
--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -1,0 +1,29 @@
+{% macro render_quadrant(title, color_class, tasks) %}
+<div class="col-md-6">
+    <div class="card h-100">
+        <div class="card-header {{ color_class }}">{{ title }}</div>
+        <div class="card-body">
+            {% if tasks %}
+            <ul class="list-unstyled mb-0">
+                {% for task in tasks %}
+                <li class="d-flex justify-content-between align-items-center mb-2">
+                    <div>
+                        <span class="{{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</span>
+                        {% if task.deadline %}<small class="text-muted ms-2">{{ task.deadline.strftime('%Y-%m-%d') }}</small>{% endif %}
+                        {% if task.completed %}<span class="badge bg-success ms-2">Done</span>{% endif %}
+                    </div>
+                    <div class="btn-group">
+                        <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-sm btn-outline-primary">{{ 'Undo' if task.completed else 'Complete' }}</a>
+                        <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                        <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger">Delete</a>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="text-muted">No tasks</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,134 +22,17 @@
             <a href="{{ url_for('add_task') }}" class="btn btn-success">Add Task</a>
         </div>
 
+        {% from '_macros.html' import render_quadrant %}
+        {% set quadrants = [
+            (1, 'Urgent & Important', 'bg-danger text-white'),
+            (2, 'Not Urgent & Important', 'bg-warning text-dark'),
+            (3, 'Urgent & Not Important', 'bg-primary text-white'),
+            (4, 'Not Urgent & Not Important', 'bg-secondary text-white')
+        ] %}
         <div class="row g-4">
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-header bg-danger text-white">Urgent &amp; Important</div>
-                    <div class="card-body">
-                        {% if tasks[1] %}
-                        <ul class="list-unstyled mb-0">
-                            {% for task in tasks[1] %}
-                            <li class="d-flex justify-content-between align-items-center mb-2">
-                                <div>
-                                    <span class="{{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</span>
-
-
-                                    {% if task.deadline %}<small class="text-muted ms-2">{{ task.deadline.strftime('%Y-%m-%d') }}</small>{% endif %}
-
-
-                                    {% if task.completed %}<span class="badge bg-success ms-2">Done</span>{% endif %}
-                                </div>
-                                <div class="btn-group">
-                                    <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-sm btn-outline-primary">{{ 'Undo' if task.completed else 'Complete' }}</a>
-                                    <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
-                                    <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger">Delete</a>
-                                </div>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% else %}
-                        <p class="text-muted">No tasks</p>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-header bg-warning text-dark">Not Urgent &amp; Important</div>
-                    <div class="card-body">
-                        {% if tasks[2] %}
-                        <ul class="list-unstyled mb-0">
-                            {% for task in tasks[2] %}
-                            <li class="d-flex justify-content-between align-items-center mb-2">
-                                <div>
-                                    <span class="{{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</span>
-
-
-
-                                    {% if task.deadline %}<small class="text-muted ms-2">{{ task.deadline.strftime('%Y-%m-%d') }}</small>{% endif %}
-
-                                    {% if task.completed %}<span class="badge bg-success ms-2">Done</span>{% endif %}
-                                </div>
-                                <div class="btn-group">
-                                    <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-sm btn-outline-primary">{{ 'Undo' if task.completed else 'Complete' }}</a>
-                                    <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
-                                    <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger">Delete</a>
-                                </div>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% else %}
-                        <p class="text-muted">No tasks</p>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="row g-4 mt-1">
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-header bg-primary text-white">Urgent &amp; Not Important</div>
-                    <div class="card-body">
-                        {% if tasks[3] %}
-                        <ul class="list-unstyled mb-0">
-                            {% for task in tasks[3] %}
-                            <li class="d-flex justify-content-between align-items-center mb-2">
-                                <div>
-                                    <span class="{{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</span>
-
-
-
-                                    {% if task.deadline %}<small class="text-muted ms-2">{{ task.deadline.strftime('%Y-%m-%d') }}</small>{% endif %}
-
-                                    {% if task.completed %}<span class="badge bg-success ms-2">Done</span>{% endif %}
-                                </div>
-                                <div class="btn-group">
-                                    <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-sm btn-outline-primary">{{ 'Undo' if task.completed else 'Complete' }}</a>
-                                    <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
-                                    <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger">Delete</a>
-                                </div>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% else %}
-                        <p class="text-muted">No tasks</p>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-header bg-secondary text-white">Not Urgent &amp; Not Important</div>
-                    <div class="card-body">
-                        {% if tasks[4] %}
-                        <ul class="list-unstyled mb-0">
-                            {% for task in tasks[4] %}
-                            <li class="d-flex justify-content-between align-items-center mb-2">
-                                <div>
-                                    <span class="{{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</span>
-
-
-                                    {% if task.deadline %}<small class="text-muted ms-2">{{ task.deadline.strftime('%Y-%m-%d') }}</small>{% endif %}
-
-
-                                    {% if task.completed %}<span class="badge bg-success ms-2">Done</span>{% endif %}
-                                </div>
-                                <div class="btn-group">
-                                    <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-sm btn-outline-primary">{{ 'Undo' if task.completed else 'Complete' }}</a>
-                                    <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
-                                    <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger">Delete</a>
-                                </div>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% else %}
-                        <p class="text-muted">No tasks</p>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
+            {% for qid, title, color in quadrants %}
+                {{ render_quadrant(title, color, tasks[qid]) }}
+            {% endfor %}
         </div>
         {% endif %}
     </div>
@@ -157,4 +40,3 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- Extract repeated quadrant card markup into `_macros.html`
- Render quadrants in `index.html` via a new `render_quadrant` Jinja macro

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6477ff0a48328b3ee1e20872e72dd