### PR TITLE
Refactor queries to use session lookups

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
 
 from models import db, User, Task
+from sqlalchemy import select
 
 load_dotenv()
 
@@ -75,7 +76,9 @@ def login_required(f):
 def get_user_task_or_404(task_id: int, current_user: User) -> Task:
     """Retrieve a task and ensure it belongs to the logged-in user."""
     logger.info("User %s requesting task %s", current_user.id, task_id)
-    task = Task.query.get_or_404(task_id)
+    task = db.session.get(Task, task_id)
+    if task is None:
+        abort(404)
     if task.user_id != current_user.id:
         logger.warning(
             "User %s forbidden from task %s owned by %s",
@@ -108,7 +111,9 @@ def index():
 @app.route("/tasks/<int:task_id>/toggle")
 @login_required
 def toggle_task(task_id: int):
-    current_user = User.query.get_or_404(session["user_id"])
+    current_user = db.session.get(User, session["user_id"])
+    if current_user is None:
+        abort(404)
     task = get_user_task_or_404(task_id, current_user)
     task.completed = not task.completed
     db.session.commit()
@@ -130,7 +135,9 @@ def authorize():
     token = google.authorize_access_token()
     user_info = google.parse_id_token(token)
 
-    user = User.query.filter_by(google_id=user_info["sub"]).first()
+    user = db.session.execute(
+        select(User).filter_by(google_id=user_info["sub"])
+    ).scalar_one_or_none()
     if user is None:
         email = user_info.get("email")
         if email is None:
@@ -179,7 +186,9 @@ def add_task():
 @app.route("/task/<int:task_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit_task(task_id):
-    current_user = User.query.get_or_404(session["user_id"])
+    current_user = db.session.get(User, session["user_id"])
+    if current_user is None:
+        abort(404)
     task = get_user_task_or_404(task_id, current_user)
 
     if request.method == "POST":
@@ -198,7 +207,9 @@ def edit_task(task_id):
 @app.route("/task/<int:task_id>/delete", methods=["GET", "POST"])
 @login_required
 def delete_task(task_id):
-    current_user = User.query.get_or_404(session["user_id"])
+    current_user = db.session.get(User, session["user_id"])
+    if current_user is None:
+        abort(404)
     task = get_user_task_or_404(task_id, current_user)
 
     if request.method == "POST":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app import app, db, google, User
+from sqlalchemy import select
 
 
 def test_authorize_with_email(client, monkeypatch):
@@ -19,7 +20,9 @@ def test_authorize_with_email(client, monkeypatch):
     response = client.get("/login/callback")
     assert response.status_code == 302
     with app.app_context():
-        user = User.query.filter_by(google_id="abc123").first()
+        user = db.session.execute(
+            select(User).filter_by(google_id="abc123")
+        ).scalar_one_or_none()
         assert user is not None
         assert user.email == "user@example.com"
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3,6 +3,7 @@ from datetime import date
 import pytest
 
 from models import db, Task, User
+from sqlalchemy import select
 
 
 def test_login_required(client):
@@ -38,7 +39,9 @@ def test_task_crud_operations(logged_in_client, user):
         follow_redirects=False,
     )
     assert resp.status_code == 302
-    task = Task.query.filter_by(title="New", user_id=user.id).first()
+    task = db.session.execute(
+        select(Task).filter_by(title="New", user_id=user.id)
+    ).scalar_one_or_none()
     assert task is not None
 
     # Update
@@ -52,7 +55,7 @@ def test_task_crud_operations(logged_in_client, user):
         },
     )
     assert resp.status_code == 302
-    task = Task.query.get(task.id)
+    task = db.session.get(Task, task.id)
     assert task.title == "Updated"
     assert task.quadrant == 2
     assert task.description == "desc"
@@ -61,11 +64,11 @@ def test_task_crud_operations(logged_in_client, user):
     # Toggle completion
     resp = logged_in_client.get(f"/tasks/{task.id}/toggle")
     assert resp.status_code == 302
-    task = Task.query.get(task.id)
+    task = db.session.get(Task, task.id)
     assert task.completed is True
 
     # Delete
     resp = logged_in_client.post(f"/task/{task.id}/delete")
     assert resp.status_code == 302
-    assert Task.query.get(task.id) is None
+    assert db.session.get(Task, task.id) is None
 


### PR DESCRIPTION
## Summary
- Replace `get_or_404` and query helper usage with `db.session.get` plus explicit 404 checks
- Switch `.query.filter_by(...).first()` patterns to `select` with `db.session.execute`
- Adjust tests to use session-based lookups

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c64a089784832893326742f3ee7182