### PR TITLE
Ensure Google OAuth client is always defined

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,7 @@ google = oauth.register(
 )
 if google is None:
     raise RuntimeError("Failed to register Google OAuth client")
+assert google is not None
 
 db.init_app(app)
 
@@ -117,17 +118,13 @@ def toggle_task(task_id: int):
 @app.route("/login")
 def login():
     redirect_uri = url_for("authorize", _external=True)
-    if google is None:
-        abort(500, description="OAuth client not configured")
-    return google.authorize_redirect(redirect_uri)
+    return oauth.google.authorize_redirect(redirect_uri)
 
 
 @app.route("/login/callback")
 def authorize():
-    if google is None:
-        abort(500, description="OAuth client not configured")
-    token = google.authorize_access_token()
-    user_info = google.parse_id_token(token)
+    token = oauth.google.authorize_access_token()
+    user_info = oauth.google.parse_id_token(token)
 
     user = db.session.execute(
         select(User).filter_by(google_id=user_info["sub"])


### PR DESCRIPTION
## Summary
- assert Google OAuth client registration to satisfy type checker
- simplify login and authorize routes using `oauth.google` directly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7119206048328a999cba3e7944b99