### PR TITLE
Validate Google OAuth credentials on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,16 @@ if google is None:
     raise RuntimeError("Failed to register Google OAuth client")
 assert google is not None
 
+if not google.client_id:
+    raise RuntimeError(
+        "GOOGLE_CLIENT_ID is missing. Set the GOOGLE_CLIENT_ID environment variable or provide it in a .env file."
+    )
+
+if not google.client_secret:
+    raise RuntimeError(
+        "GOOGLE_CLIENT_SECRET is missing. Set the GOOGLE_CLIENT_SECRET environment variable or provide it in a .env file."
+    )
+
 db.init_app(app)
 
 with app.app_context():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-client-secret")
+
 from app import app as flask_app
 from models import db, User
 


### PR DESCRIPTION
## Summary
- validate that GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are configured when registering Google OAuth
- configure test environment with dummy Google OAuth credentials

## Testing
- `pre-commit run --files app.py tests/conftest.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c717187a588328a3f3f8dfe6d7a940