### PR TITLE
Require SECRET_KEY environment variable at startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,10 @@ app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
     "DATABASE_URL", "sqlite:///schedulist.db"
 )
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.secret_key = os.getenv("SECRET_KEY", "dev")
+try:
+    app.secret_key = os.environ["SECRET_KEY"]
+except KeyError as exc:
+    raise RuntimeError("SECRET_KEY environment variable not set") from exc
 
 oauth = OAuth(app)
 google = oauth.register(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app import app as flask_app


### PR DESCRIPTION
## Summary
- Fail fast when SECRET_KEY is missing by strictly loading it from the environment
- Provide a clear startup error if SECRET_KEY is absent
- Set SECRET_KEY for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c71717c5d48328a4e1e139e312b033