### PR TITLE
Add root route and update dashboard path

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,8 +85,12 @@ def get_user_task_or_404(task_id: int, current_user: User) -> Task:
         abort(403)
     return task
 
-
 @app.route("/")
+def root():
+    return "Server is running"
+
+
+@app.route("/dashboard")
 @login_required
 def index():
     user_id = session["user_id"]
@@ -215,4 +219,4 @@ if __name__ == "__main__":
     with app.app_context():
         db.create_all()
 
-    app.run()
+    app.run(debug=True)

--- a/tests/test_task_order.py
+++ b/tests/test_task_order.py
@@ -43,7 +43,7 @@ def test_tasks_ordered_and_deadline_displayed(client):
         sess["user_id"] = user_id
         sess["user"] = {"email": "user@example.com"}
 
-    response = client.get("/")
+    response = client.get("/dashboard")
     assert response.status_code == 200
     text = response.get_data(as_text=True)
     assert "2023-01-01" in text

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3,10 +3,15 @@ from datetime import date
 from models import db, Task, User
 from sqlalchemy import select
 
+def test_root_route(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Server is running" in response.data
+
 
 def test_login_required(client):
-    """The index view should redirect anonymous users to login."""
-    response = client.get("/")
+    """The dashboard view should redirect anonymous users to login."""
+    response = client.get("/dashboard")
     assert response.status_code == 302
     assert "/login" in response.headers["Location"]
 


### PR DESCRIPTION
## Summary
- Expose public root route returning a simple health message
- Move task dashboard to `/dashboard` and keep login protection
- Enable debug mode in `app.run` for easier local development

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64c4223588328a9ce0f1482f866f2