### PR TITLE
Configure debug mode via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ task and view it in the matrix on the home page.
 
 Usage will expand as features are implemented.
 
+### Debug mode
+
+For local development, you can enable Flask's debug mode by setting the
+`FLASK_DEBUG` environment variable:
+
+```bash
+export FLASK_DEBUG=1  # or "true"
+python app.py
+# or
+flask --app app run
+```
+
+When `FLASK_DEBUG` is unset or set to any other value, the application runs
+with debug mode disabled.
+
 ## Google OAuth Setup
 
 To try logging in with Google, copy `.env.example` to `.env` and fill in:

--- a/app.py
+++ b/app.py
@@ -230,4 +230,11 @@ if __name__ == "__main__":
     with app.app_context():
         db.create_all()
 
-    app.run(debug=True)
+    debug = os.getenv("FLASK_DEBUG", "false").lower() in {
+        "1",
+        "true",
+        "t",
+        "yes",
+        "y",
+    }
+    app.run(debug=debug)


### PR DESCRIPTION
## Summary
- make app debug mode configurable via FLASK_DEBUG env var
- document enabling debug mode for local development

## Testing
- `pre-commit run --files app.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c722be4d188328a9694a44b444ea9c