### PR TITLE
Handle invalid task deadlines

### DIFF
--- a/app.py
+++ b/app.py
@@ -183,7 +183,16 @@ def add_task():
             user_id=session["user_id"],
         )
         if deadline_str:
-            task.deadline = datetime.strptime(deadline_str, "%Y-%m-%d").date()
+            try:
+                task.deadline = datetime.strptime(deadline_str, "%Y-%m-%d").date()
+            except ValueError:
+                error = "Invalid date format. Please use YYYY-MM-DD."
+                return (
+                    render_template(
+                        "add_task.html", error=error, user=session.get("user")
+                    ),
+                    400,
+                )
         db.session.add(task)
         db.session.commit()
         return redirect(url_for("index"))
@@ -202,9 +211,22 @@ def edit_task(task_id):
         task.title = request.form["title"]
         task.description = request.form.get("description")
         deadline_str = request.form.get("deadline")
-        task.deadline = (
-            datetime.strptime(deadline_str, "%Y-%m-%d").date() if deadline_str else None
-        )
+        if deadline_str:
+            try:
+                task.deadline = datetime.strptime(deadline_str, "%Y-%m-%d").date()
+            except ValueError:
+                error = "Invalid date format. Please use YYYY-MM-DD."
+                return (
+                    render_template(
+                        "edit_task.html",
+                        task=task,
+                        error=error,
+                        user=session.get("user"),
+                    ),
+                    400,
+                )
+        else:
+            task.deadline = None
         task.quadrant = int(request.form["quadrant"])
         db.session.commit()
         return redirect(url_for("index"))

--- a/templates/add_task.html
+++ b/templates/add_task.html
@@ -10,6 +10,9 @@
 <body>
     <div class="container py-4">
         <h1 class="mb-4">Add Task</h1>
+        {% if error %}
+        <div class="alert alert-danger">{{ error }}</div>
+        {% endif %}
         <form method="post" class="row g-3">
             <div class="col-md-6 form-section">
                 <label for="title" class="form-label">Title</label>

--- a/templates/edit_task.html
+++ b/templates/edit_task.html
@@ -10,6 +10,9 @@
 <body>
     <div class="container py-4">
         <h1 class="mb-4">Edit Task</h1>
+        {% if error %}
+        <div class="alert alert-danger">{{ error }}</div>
+        {% endif %}
         <form method="post" class="row g-3">
             <div class="col-md-6 form-section">
                 <label for="title" class="form-label">Title</label>

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -79,3 +79,26 @@ def test_task_crud_operations(logged_in_client, user):
     assert db.session.get(Task, task.id) is None
 
 
+def test_add_task_invalid_deadline(logged_in_client):
+    resp = logged_in_client.post(
+        "/add",
+        data={"title": "Bad", "quadrant": "1", "deadline": "not-a-date"},
+    )
+    assert resp.status_code == 400
+    assert b"Invalid date format" in resp.data
+    assert Task.query.filter_by(title="Bad").first() is None
+
+
+def test_edit_task_invalid_deadline(logged_in_client, user):
+    task = Task(title="T", quadrant=1, user_id=user.id)
+    db.session.add(task)
+    db.session.commit()
+    resp = logged_in_client.post(
+        f"/task/{task.id}/edit",
+        data={"title": "T", "quadrant": "1", "deadline": "not-a-date"},
+    )
+    assert resp.status_code == 400
+    assert b"Invalid date format" in resp.data
+    db.session.refresh(task)
+    assert task.deadline is None
+


### PR DESCRIPTION
## Summary
- Validate deadline inputs in task creation and editing, returning a 400 with an error message on invalid dates.
- Display error alerts on task forms when the date format is incorrect.
- Add regression tests for invalid deadline handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c722bb9a8c8328ab01f82f8f20eb55