### PR TITLE
Use userinfo endpoint in OAuth callback

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import logging
 import os
 from functools import wraps
 
-
 from flask import (
     Flask,
     render_template,
@@ -13,7 +12,6 @@ from flask import (
     session,
     abort,
 )
-
 
 from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
@@ -136,15 +134,16 @@ def login():
 @app.route("/login/callback")
 def authorize():
     try:
-        token = google.authorize_access_token()
+        google.authorize_access_token()
     except Exception as exc:  # pragma: no cover - oauth library error handling
         logger.exception("Failed to authorize access token: %s", exc)
         abort(400, description="Failed to authorize access token")
 
     try:
-        user_info = google.parse_id_token(token)
+        resp = google.get("userinfo")
+        user_info = resp.json()
     except Exception as exc:  # pragma: no cover - oauth library error handling
-        logger.exception("Failed to parse ID token: %s", exc)
+        logger.exception("Failed to fetch user info: %s", exc)
         abort(500, description="Failed to parse user information")
 
     user = db.session.execute(


### PR DESCRIPTION
## Summary
- switch OAuth callback to use Google's userinfo endpoint instead of ID token parsing
- remove deprecated RemoteApp type hints and register Google OAuth client with explicit configuration
- update authentication tests to mock userinfo requests

## Testing
- `pre-commit run --files app.py tests/test_auth.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c721fc785c83289df734a13ba42da2