### PR TITLE
Use Google OpenID Connect userinfo endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,7 +150,7 @@ def authorize():
         abort(400, description="Failed to authorize access token")
 
     try:
-        resp = google.get("userinfo")
+        resp = google.get("https://openidconnect.googleapis.com/v1/userinfo")
         user_info = resp.json()
     except Exception as exc:  # pragma: no cover - oauth library error handling
         logger.exception("Failed to fetch user info: %s", exc)


### PR DESCRIPTION
## Summary
- call Google OpenID Connect userinfo endpoint in the authorize callback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c73506e5a8832885d9fcb5601e7b8c