### PR TITLE
Use Google OpenID Connect userinfo endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,11 +2,7 @@ from datetime import datetime
 import logging
 import os
 from functools import wraps
-
-
-from typing import Any
-
-
+from typing import Any, cast
 
 from flask import (
     Flask,
@@ -17,14 +13,6 @@ from flask import (
     session,
     abort,
 )
-
-
-
-try:
-    from authlib.integrations.base_client import RemoteApp
-except ImportError:  # pragma: no cover - fallback for older Authlib versions
-    RemoteApp = Any  # type: ignore[assignment]
-
 
 from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
@@ -48,13 +36,18 @@ except KeyError as exc:
     raise RuntimeError("SECRET_KEY environment variable not set") from exc
 
 oauth = OAuth(app)
-google: RemoteApp = oauth.register(
+google = oauth.register(
     name="google",
     client_id=os.getenv("GOOGLE_CLIENT_ID"),
     client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
     server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
     client_kwargs={"scope": "openid email profile"},
 )
+
+if google is None:
+    raise RuntimeError("Failed to register Google OAuth client")
+
+google = cast(Any, google)
 
 if not google.client_id:
     raise RuntimeError(
@@ -150,7 +143,7 @@ def authorize():
         abort(400, description="Failed to authorize access token")
 
     try:
-        resp = google.get("userinfo")
+        resp = google.get("https://openidconnect.googleapis.com/v1/userinfo")
         user_info = resp.json()
     except Exception as exc:  # pragma: no cover - oauth library error handling
         logger.exception("Failed to fetch user info: %s", exc)


### PR DESCRIPTION
## Summary
- call Google OpenID Connect userinfo endpoint in the authorize callback
- verify Google OAuth registration succeeds and cast the client to `Any` for cleaner type checking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73506e5a8832885d9fcb5601e7b8c