### PR TITLE
Allow empty deadlines in task forms

### DIFF
--- a/templates/add_task.html
+++ b/templates/add_task.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 
-
 {% block title %}Add Task · Schedulist{% endblock %}
 
 {% block content %}
@@ -18,8 +17,9 @@
                         <input type="text" class="form-control" id="title" name="title" value="{{ request.form.get('title', '') }}" required autofocus>
                     </div>
                     <div>
-                        <label for="deadline" class="form-label">Deadline</label>
-                        <input type="date" class="form-control" id="deadline" name="deadline" value="{{ request.form.get('deadline', '') }}" required min="2000-01-01" max="2099-12-31">
+                        <label for="deadline" class="form-label">Deadline <span class="text-muted">(optional)</span></label>
+                        <input type="date" class="form-control" id="deadline" name="deadline" value="{{ request.form.get('deadline', '') }}" min="2000-01-01" max="2099-12-31">
+                        <div class="form-text">Leave blank if this task does not have a deadline.</div>
                     </div>
                     <div>
                         <label for="description" class="form-label">Description</label>
@@ -37,44 +37,6 @@
                 </form>
             </div>
         </div>
-
     </div>
 </div>
-
-
-    </div>
-</div>
-
-    </div>
-</div>
-
-{% block content %}
-<h1 class="mb-4">Add Task</h1>
-{% if error %}
-<div class="alert alert-danger">{{ error }}</div>
-{% endif %}
-<form method="post">
-    <div class="mb-3">
-        <label for="title" class="form-label">Title</label>
-        <input type="text" class="form-control" id="title" name="title" required>
-    </div>
-    <div class="mb-3">
-        <label for="deadline" class="form-label">Deadline</label>
-        <input type="date" class="form-control" id="deadline" name="deadline" required min="2000-01-01" max="2099-12-31">
-    </div>
-    <div class="mb-3">
-        <label for="description" class="form-label">Description</label>
-        <textarea class="form-control" id="description" name="description"></textarea>
-    </div>
-    <div class="mb-3">
-        <label for="quadrant" class="form-label">Quadrant</label>
-        <input type="number" class="form-control" id="quadrant" name="quadrant" required min="1" max="4">
-        <div class="form-text">1: Urgent &amp; Important, 2: Not Urgent &amp; Important, 3: Urgent &amp; Not Important, 4: Not Urgent &amp; Not Important</div>
-    </div>
-    <button type="submit" class="btn btn-primary">Add Task</button>
-    <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
-</form>
-
-
-
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,33 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <title>{% block title %}Schedulist{% endblock %}</title>
+    <title>Schedulist</title>
     <link
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         rel="stylesheet"
         integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw"
         crossorigin="anonymous"
     >
-
-
-
-    <title>Schedulist</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEJo0MDwo5CMi9kgIIEYBLETQBxl0G6DpPkk58ty1N+tnMw" crossorigin="anonymous">
-
-
-
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
 </head>
 <body>
-
-    {% set current_endpoint = request.endpoint or '' %}
-
-
-
-
-
     {% set current_endpoint = request.endpoint or '' %}
 
     <nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom shadow-sm">
@@ -44,23 +28,10 @@
                 aria-expanded="false"
                 aria-label="Toggle navigation"
             >
-
-
-
-
-    <nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
-        <div class="container">
-            <a class="navbar-brand" href="{{ url_for('index') }}">Schedulist</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-
-
-
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
-
-
                     <li class="nav-item">
                         <a class="nav-link {% if current_endpoint == 'index' %}active{% endif %}" aria-current="page" href="{{ url_for('index') }}">Dashboard</a>
                     </li>
@@ -70,20 +41,10 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
                     </li>
-
-
-
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Dashboard</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('add_task') }}">Add Task</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
-
-
-
                 </ul>
             </div>
         </div>
     </nav>
-
 
     <main class="py-4">
         <div class="container">
@@ -97,47 +58,5 @@
         integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3"
         crossorigin="anonymous"
     ></script>
-
-
-    <main class="py-4">
-        <div class="container">
-            {% block content %}{% endblock %}
-        </div>
-    </main>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>
-
-
-    <div class="container py-4">
-        {% block content %}{% endblock %}
-    </div>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>
-
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="{{ url_for('index') }}">Schedulist</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Dashboard</a></li>
-                <li class="nav-item"><a class="nav-link" href="{{ url_for('add_task') }}">Add Task</a></li>
-                <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
-            </ul>
-        </div>
-    </div>
-</nav>
-
-<div class="container py-4">
-{% block content %}{% endblock %}
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-g8m0MQ0miEJeZVrDCTnhgypKekJy5o+1OtSWT8gKa5IhXCTITVEWilR92qT9bkH3" crossorigin="anonymous"></script>
-
-
-
-
 </body>
 </html>

--- a/templates/edit_task.html
+++ b/templates/edit_task.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 
-
 {% block title %}Edit Task · Schedulist{% endblock %}
 
 {% block content %}
@@ -18,8 +17,9 @@
                         <input type="text" class="form-control" id="title" name="title" value="{{ task.title }}" required>
                     </div>
                     <div>
-                        <label for="deadline" class="form-label">Deadline</label>
-                        <input type="date" class="form-control" id="deadline" name="deadline" value="{{ task.deadline.strftime('%Y-%m-%d') if task.deadline else '' }}" required min="2000-01-01" max="2099-12-31">
+                        <label for="deadline" class="form-label">Deadline <span class="text-muted">(optional)</span></label>
+                        <input type="date" class="form-control" id="deadline" name="deadline" value="{{ task.deadline.strftime('%Y-%m-%d') if task.deadline else '' }}" min="2000-01-01" max="2099-12-31">
+                        <div class="form-text">Leave blank to remove the deadline.</div>
                     </div>
                     <div>
                         <label for="description" class="form-label">Description</label>
@@ -37,44 +37,6 @@
                 </form>
             </div>
         </div>
-
     </div>
 </div>
-
-
-    </div>
-</div>
-
-    </div>
-</div>
-
-{% block content %}
-<h1 class="mb-4">Edit Task</h1>
-{% if error %}
-<div class="alert alert-danger">{{ error }}</div>
-{% endif %}
-<form method="post">
-    <div class="mb-3">
-        <label for="title" class="form-label">Title</label>
-        <input type="text" class="form-control" id="title" name="title" value="{{ task.title }}" required>
-    </div>
-    <div class="mb-3">
-        <label for="deadline" class="form-label">Deadline</label>
-        <input type="date" class="form-control" id="deadline" name="deadline" value="{{ task.deadline.strftime('%Y-%m-%d') if task.deadline else '' }}" required min="2000-01-01" max="2099-12-31">
-    </div>
-    <div class="mb-3">
-        <label for="description" class="form-label">Description</label>
-        <textarea class="form-control" id="description" name="description">{{ task.description }}</textarea>
-    </div>
-    <div class="mb-3">
-        <label for="quadrant" class="form-label">Quadrant</label>
-        <input type="number" class="form-control" id="quadrant" name="quadrant" value="{{ task.quadrant }}" required min="1" max="4">
-        <div class="form-text">1: Urgent &amp; Important, 2: Not Urgent &amp; Important, 3: Urgent &amp; Not Important, 4: Not Urgent &amp; Not Important</div>
-    </div>
-    <button type="submit" class="btn btn-primary">Update Task</button>
-    <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
-</form>
-
-
-
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,15 +1,4 @@
-
-{% extends "base.html" %}
-
-
-
-{% extends "base.html" %}
-
-
-
-{% extends "base.html" %}
-
-
+{% extends 'base.html' %}
 
 {% block title %}Dashboard · Schedulist{% endblock %}
 
@@ -17,47 +6,19 @@
 {% if user %}
 <h1 class="mb-4">Dashboard</h1>
 <div class="row row-cols-1 row-cols-md-2 g-4">
-
-
-
-
-{% extends "base.html" %}
-
-{% block content %}
-{% if user %}
-<div class="row g-4">
-
-
-
     {% set quadrants = [
-        (1, "Urgent & Important", "bg-danger text-white"),
-        (2, "Not Urgent & Important", "bg-primary text-white"),
-        (3, "Urgent & Not Important", "bg-warning text-dark"),
-        (4, "Not Urgent & Not Important", "bg-success text-white")
+        (1, 'Urgent & Important', 'bg-danger text-white'),
+        (2, 'Not Urgent & Important', 'bg-primary text-white'),
+        (3, 'Urgent & Not Important', 'bg-warning text-dark'),
+        (4, 'Not Urgent & Not Important', 'bg-success text-white')
     ] %}
     {% for qid, title, header_class in quadrants %}
-
     <div class="col">
         <div class="card quadrant-card h-100 shadow-sm">
-
-
-    <div class="col">
-        <div class="card quadrant-card h-100 shadow-sm">
-
-
-    <div class="col">
-        <div class="card quadrant-card h-100 shadow-sm">
-
-    <div class="col-12 col-md-6">
-        <div class="card h-100 shadow-sm">
-
-
-
             <div class="card-header {{ header_class }}">
                 <h5 class="mb-0">{{ title }}</h5>
             </div>
             <div class="card-body">
-
                 {% set quadrant_tasks = tasks.get(qid, []) %}
                 {% if quadrant_tasks %}
                 <div class="d-flex flex-column gap-3">
@@ -72,55 +33,10 @@
                                 <i class="bi bi-calendar-event me-1"></i>
                                 {{ task.deadline.strftime('%Y-%m-%d') }}
                             </h6>
-
-
-                {% if tasks[qid] %}
-
-                <div class="d-flex flex-column gap-3">
-
-                <div class="vstack gap-3">
-
-                    {% for task in tasks[qid] %}
-                    <div class="card task-card">
-                        <div class="card-body">
-                            <h5 class="card-title {{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</h5>
-                            {% if task.deadline %}
-                            <h6 class="card-subtitle mb-2 text-muted">
-                                <i class="bi bi-calendar-event me-1"></i>{{ task.deadline.strftime('%Y-%m-%d') }}
-                            </h6>
-
-
-{% extends 'base.html' %}
-
-{% block content %}
-{% if user %}
-<div class="row row-cols-1 row-cols-md-2 g-4">
-    {% set quadrants = [
-        (1, 'Urgent & Important', 'bg-danger text-white'),
-        (2, 'Not Urgent & Important', 'bg-primary text-white'),
-        (3, 'Urgent & Not Important', 'bg-warning text-dark'),
-        (4, 'Not Urgent & Not Important', 'bg-success text-white')
-    ] %}
-    {% for qid, title, classes in quadrants %}
-    <div class="col">
-        <div class="card h-100">
-            <div class="card-header {{ classes }}">{{ title }}</div>
-            <div class="card-body">
-                {% if tasks[qid] %}
-                    {% for task in tasks[qid] %}
-                    <div class="card task-card mb-3">
-                        <div class="card-body">
-                            <h5 class="card-title {{ 'text-decoration-line-through' if task.completed else '' }}">{{ task.title }}</h5>
-                            {% if task.deadline %}
-                            <h6 class="card-subtitle mb-2 text-muted"><i class="bi bi-calendar-event"></i> {{ task.deadline.strftime('%Y-%m-%d') }}</h6>
-
-
-
                             {% endif %}
                             {% if task.description %}
                             <p class="card-text">{{ task.description }}</p>
                             {% endif %}
-
                             <div class="btn-group btn-group-sm" role="group">
                                 <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-outline-secondary">
                                     <i class="bi bi-pencil"></i> Edit
@@ -129,18 +45,6 @@
                                     <i class="bi bi-trash"></i> Delete
                                 </a>
                                 <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-outline-success">
-
-
-
-
-                            <div class="btn-group" role="group">
-                                <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-pencil"></i> Edit</a>
-                                <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i> Delete</a>
-                                <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-sm btn-outline-success">
-
-
-
-
                                     {% if task.completed %}
                                     <i class="bi bi-arrow-counterclockwise"></i> Undo
                                     {% else %}
@@ -151,22 +55,7 @@
                         </div>
                     </div>
                     {% endfor %}
-
                 </div>
-
-
-                </div>
-
-
-                </div>
-
-
-                </div>
-
-              
-
-
-
                 {% else %}
                 <div class="alert alert-secondary text-center mb-0" role="alert">No tasks yet.</div>
                 {% endif %}


### PR DESCRIPTION
## Summary
- allow leaving the deadline blank on the add and edit task forms while clarifying that the field is optional
- streamline shared base and dashboard templates to remove duplicate content blocks and keep the layout consistent

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9a3276d2483288abfa3aacc3d7262