### PR TITLE
Fix dashboard template rendering and add regression test

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,9 +23,10 @@
                 {% if quadrant_tasks %}
                 <div class="d-flex flex-column gap-3">
                     {% for task in quadrant_tasks %}
+                    {% set title_classes = 'text-decoration-line-through' if task.completed else '' %}
                     <div class="card task-card">
                         <div class="card-body">
-                            <h5 class="card-title {{ 'text-decoration-line-through' if task.completed else '' }}">
+                            <h5 class="card-title {{ title_classes }}">
                                 {{ task.title }}
                             </h5>
                             {% if task.deadline %}
@@ -44,12 +45,10 @@
                                 <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-outline-danger">
                                     <i class="bi bi-trash"></i> Delete
                                 </a>
+                                {% set action_icon = 'bi-arrow-counterclockwise' if task.completed else 'bi-check' %}
+                                {% set action_label = 'Undo' if task.completed else 'Done' %}
                                 <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-outline-success">
-                                    {% if task.completed %}
-                                    <i class="bi bi-arrow-counterclockwise"></i> Undo
-                                    {% else %}
-                                    <i class="bi bi-check"></i> Done
-                                    {% endif %}
+                                    <i class="bi {{ action_icon }}"></i> {{ action_label }}
                                 </a>
                             </div>
                         </div>

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -16,6 +16,14 @@ def test_login_required(client):
     assert "/login" in response.headers["Location"]
 
 
+def test_dashboard_template_renders(logged_in_client):
+    """The dashboard page should render successfully for logged-in users."""
+    response = logged_in_client.get("/dashboard")
+    assert response.status_code == 200
+    assert b"Dashboard" in response.data
+    assert b"No tasks yet." in response.data
+
+
 def test_tasks_limited_to_session_user(client, app):
     """Accessing another user's task should return 403."""
     user1 = User(username="u1@example.com", google_id="gid1", email="u1@example.com")


### PR DESCRIPTION
## Summary
- adjust the dashboard template to compute toggle button state without nested block conditionals
- add a regression test to ensure the dashboard renders successfully for a logged-in user

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b6f2c39483288cd618e83337c225