### PR TITLE
Streamline dashboard header and card layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 import logging
 import os
 from functools import wraps
@@ -125,7 +125,10 @@ def index():
         for q in range(1, 5)
     }
     return render_template(
-        "index.html", tasks=tasks_by_quadrant, user=session.get("user")
+        "index.html",
+        tasks=tasks_by_quadrant,
+        user=session.get("user"),
+        today=date.today(),
     )
 
 

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,42 +1,308 @@
-
 body {
-    background-color: #f8f9fb;
+    font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+    background: linear-gradient(180deg, #f7f9fc 0%, #ffffff 45%, #f0f4ff 100%);
+    color: var(--bs-body-color);
+}
+
+.dashboard-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.dashboard-title {
+    color: var(--bs-emphasis-color);
+}
+
+[data-bs-theme="dark"] .dashboard-title {
+    color: #f5f5f5;
+}
+
+[data-bs-theme="dark"] body {
+    background: #121212;
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+main {
+    padding-bottom: 5rem;
+}
+
+.navbar {
+    box-shadow: 0 1rem 3rem rgba(15, 23, 42, 0.08);
+    background-color: rgba(255, 255, 255, 0.95) !important;
+    backdrop-filter: blur(6px);
+}
+
+.navbar-title-mobile {
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+[data-bs-theme="dark"] .navbar {
+    background-color: rgba(15, 23, 42, 0.85) !important;
+    box-shadow: 0 1rem 3rem rgba(2, 6, 23, 0.5);
 }
 
 .navbar-brand {
     letter-spacing: 0.02em;
 }
 
-.quadrant-card {
-    border: none;
-    border-radius: 0.75rem;
-    overflow: hidden;
+.navbar .nav-link {
+    position: relative;
+    font-weight: 500;
+    color: var(--bs-body-color);
+    transition: color 0.2s ease, transform 0.2s ease;
 }
 
-.quadrant-card .card-header {
+.navbar .nav-link i {
+    font-size: 1.05rem;
+    line-height: 1;
+}
+
+.navbar .nav-link:hover,
+.navbar .nav-link:focus {
+    color: var(--bs-primary);
+}
+
+.navbar .nav-link.active {
+    color: var(--bs-primary);
     font-weight: 600;
 }
 
+.navbar .nav-link.active::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.35rem;
+    width: 100%;
+    height: 0.2rem;
+    background-color: var(--bs-primary);
+    border-radius: 999px;
+}
+
+.quadrant-card {
+    border: none;
+    border-radius: 1rem;
+    box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+    background-color: var(--bs-card-bg);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+[data-bs-theme="dark"] .card {
+    --bs-card-bg: #1e1e1e;
+    --bs-card-color: #f5f5f5;
+    --bs-card-border-color: #333;
+    background-color: #1e1e1e;
+    color: #f5f5f5;
+    border: 1px solid #333;
+}
+
+[data-bs-theme="dark"] .card-header {
+    --bs-card-cap-bg: #2a2a2a;
+    --bs-card-cap-color: #f5f5f5;
+    background-color: #2a2a2a;
+    border-bottom: 1px solid #333;
+    color: #f5f5f5;
+}
+
+[data-bs-theme="dark"] .card-header.bg-danger {
+    background-color: #b02a37 !important;
+}
+
+[data-bs-theme="dark"] .card-header.bg-primary {
+    background-color: #0b5ed7 !important;
+}
+
+[data-bs-theme="dark"] .card-header.bg-warning {
+    background-color: #d39e00 !important;
+    color: #1e1e1e;
+}
+
+[data-bs-theme="dark"] .card-header.bg-success {
+    background-color: #146c43 !important;
+}
+
+[data-bs-theme="dark"] .text-muted {
+    color: #aaaaaa !important;
+}
+
+[data-bs-theme="dark"] .quadrant-card {
+    background-color: #1e1e1e;
+    border: 1px solid #333;
+    box-shadow: 0 1.5rem 3rem rgba(2, 6, 23, 0.6);
+    color: #f5f5f5;
+}
+
+.quadrant-card .card-header {
+    border: none;
+    padding: 1rem 1.5rem;
+    font-weight: 600;
+}
+
+.quadrant-card .card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    flex-grow: 1;
+}
+
+.task-list {
+    flex-grow: 1;
+}
+
+.dashboard-grid > .col {
+    display: flex;
+}
+
+.dashboard-grid > .col > .quadrant-card {
+    width: 100%;
+}
+
+.quadrant-card .quadrant-icon {
+    font-size: 1.5rem;
+}
+
+.progress {
+    border-radius: 999px;
+    background-color: rgba(15, 23, 42, 0.08);
+}
+
+[data-bs-theme="dark"] .progress {
+    background-color: #2a2a2a;
+    border: 1px solid #333;
+}
+
+.progress-bar {
+    border-radius: 999px;
+}
+
+[data-bs-theme="dark"] .progress-bar.bg-danger {
+    background-color: #a61d2d !important;
+}
+
+[data-bs-theme="dark"] .progress-bar.bg-primary {
+    background-color: #0a58ca !important;
+}
+
+[data-bs-theme="dark"] .progress-bar.bg-warning {
+    background-color: #b8860b !important;
+    color: #1e1e1e;
+}
+
+[data-bs-theme="dark"] .progress-bar.bg-success {
+    background-color: #0f5132 !important;
+}
+
+.progress-meta {
+    color: #7b8794;
+}
+
+[data-bs-theme="dark"] .progress-meta {
+    color: #888888;
+}
+
 .task-card {
-    border-radius: 0.75rem;
-    border: 1px solid rgba(0, 0, 0, 0.05);
-    transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+    border: 1px solid rgba(15, 23, 42, 0.05);
+    border-radius: 1rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background-color: var(--bs-card-bg);
+}
+
+.task-card .card-body {
+    padding: 1.25rem;
 }
 
 .task-card:hover {
-    box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.1);
-    transform: translateY(-2px);
-
-
-
-.task-card {
-    transition: box-shadow 0.2s ease-in-out;
-    border-radius: 0.5rem;
+    transform: translateY(-4px);
+    box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.12);
 }
 
-.task-card:hover {
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+[data-bs-theme="dark"] .task-card {
+    background-color: #1e1e1e;
+    border: 1px solid #333 !important;
+    box-shadow: 0 1.5rem 3rem rgba(2, 6, 23, 0.4);
+    color: #f5f5f5;
+}
+
+[data-bs-theme="dark"] .task-card:hover {
+    box-shadow: 0 1.5rem 3rem rgba(2, 6, 23, 0.65);
+}
 
 
+.empty-state-card {
+    border-radius: 1rem;
+    background-color: rgba(241, 245, 255, 0.6);
+    border: 1px dashed rgba(99, 102, 241, 0.4);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+}
 
+.empty-state-card i {
+    color: rgba(71, 85, 105, 0.7);
+}
+
+[data-bs-theme="dark"] .empty-state-card {
+    background-color: #1e1e1e;
+    border: 1px solid #333 !important;
+    color: #f5f5f5;
+}
+
+[data-bs-theme="dark"] .empty-state-card i {
+    color: #f5f5f5;
+}
+
+.fab {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    z-index: 1030;
+}
+
+.fab:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 1.5rem 3rem rgba(13, 110, 253, 0.35);
+}
+
+.theme-toggle {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    line-height: 1;
+}
+
+.theme-toggle .theme-toggle-icon {
+    font-size: 1.1rem;
+}
+
+@media (max-width: 575.98px) {
+    .fab {
+        bottom: 16px;
+        right: 16px;
+    }
+
+    .navbar .nav-link.active::after {
+        bottom: -0.2rem;
+    }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,9 +1,58 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Schedulist{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+    >
+    <script>
+        (function () {
+            const storageKey = 'theme';
+
+            const getStoredTheme = () => {
+                try {
+                    return window.localStorage.getItem(storageKey);
+                } catch (error) {
+                    return null;
+                }
+            };
+
+            const setStoredTheme = (theme) => {
+                try {
+                    window.localStorage.setItem(storageKey, theme);
+                } catch (error) {
+                    /* storage might be unavailable */
+                }
+            };
+
+            const getPreferredTheme = () => {
+                const storedTheme = getStoredTheme();
+                if (storedTheme) {
+                    return storedTheme;
+                }
+                const mediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+                return mediaQuery && mediaQuery.matches ? 'dark' : 'light';
+            };
+
+            const applyTheme = (theme) => {
+                document.documentElement.setAttribute('data-bs-theme', theme);
+            };
+
+            applyTheme(getPreferredTheme());
+
+            window.schedulistTheme = {
+                getStoredTheme,
+                setStoredTheme,
+                getPreferredTheme,
+                applyTheme,
+            };
+        })();
+    </script>
     <link
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         rel="stylesheet"
@@ -13,61 +62,163 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
     {% set current_endpoint = request.endpoint or '' %}
 
-    <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom shadow-sm">
-        <div class="container">
-            <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">Schedulist</a>
-            <button
-                class="navbar-toggler"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#navbarNav"
-                aria-controls="navbarNav"
-                aria-expanded="false"
-                aria-label="Toggle navigation"
-            >
-                <span class="navbar-toggler-icon"></span>
-            </button>
+    <nav class="navbar navbar-expand-lg bg-white">
+        <div class="container align-items-center">
+            <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">
+              {% if user and user.get('name') %}
+                Welcome, {{ user.name }}
+              {% else %}
+                Schedulist
+              {% endif %}
+            </a>
+            {% if user and user.get('name') %}
+            <div class="navbar-title-mobile d-lg-none flex-grow-1 fw-semibold text-center">
+                Schedulist
+            </div>
+            {% endif %}
+            <div class="d-flex align-items-center gap-2 ms-auto d-lg-none mobile-actions">
+                <button
+                    type="button"
+                    class="btn btn-outline-secondary btn-sm theme-toggle"
+                    data-theme-toggle
+                    aria-label="Switch to dark mode"
+                    aria-pressed="false"
+                >
+                    <span class="theme-toggle-icon" aria-hidden="true">🌞</span>
+                    <span class="visually-hidden">Toggle theme</span>
+                </button>
+                <button
+                    class="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbarNav"
+                    aria-controls="navbarNav"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation"
+                >
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            </div>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                <ul class="navbar-nav ms-lg-auto mb-2 mb-lg-0">
                     <li class="nav-item">
+                        {% set dashboard_active = current_endpoint == 'index' %}
                         <a
-                            class="nav-link {% if current_endpoint == 'index' %}active{% endif %}"
-                            aria-current="page"
+                            class="nav-link d-flex align-items-center gap-2 {{ 'active' if dashboard_active }}"
+                            {% if dashboard_active %}aria-current="page"{% endif %}
                             href="{{ url_for('index') }}"
                         >
-                            Dashboard
+                            <i class="bi bi-house-door"></i>
+                            <span>Dashboard</span>
                         </a>
                     </li>
                     <li class="nav-item">
+                        {% set add_active = current_endpoint == 'add_task' %}
                         <a
-                            class="nav-link {% if current_endpoint == 'add_task' %}active{% endif %}"
+                            class="nav-link d-flex align-items-center gap-2 {{ 'active' if add_active }}"
+                            {% if add_active %}aria-current="page"{% endif %}
                             href="{{ url_for('add_task') }}"
                         >
-                            Add Task
+                            <i class="bi bi-plus-circle"></i>
+                            <span>Add Task</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+                        <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('logout') }}">
+                            <i class="bi bi-box-arrow-right"></i>
+                            <span>Logout</span>
+                        </a>
                     </li>
                 </ul>
+                <div class="d-none d-lg-flex align-items-center ms-lg-3">
+                    <button
+                        type="button"
+                        class="btn btn-outline-secondary btn-sm theme-toggle"
+                        data-theme-toggle
+                        aria-label="Switch to dark mode"
+                        aria-pressed="false"
+                    >
+                        <span class="theme-toggle-icon" aria-hidden="true">🌞</span>
+                        <span class="visually-hidden">Toggle theme</span>
+                    </button>
+                </div>
             </div>
         </div>
     </nav>
 
-    <main class="py-4">
-        <div class="container">
-            {% block content %}
-            {% endblock %}
+    <main>
+        <div class="container py-4">
+            {% block content %}{% endblock %}
         </div>
     </main>
+
+    {% if user %}
+        <a class="btn btn-primary fab shadow" href="{{ url_for('add_task') }}" aria-label="Add task">
+            <i class="bi bi-plus-lg"></i>
+        </a>
+    {% endif %}
 
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
         crossorigin="anonymous"
     ></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const themeUtils = window.schedulistTheme || {
+                getStoredTheme: () => null,
+                setStoredTheme: () => {},
+                getPreferredTheme: () => {
+                    const mediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+                    return mediaQuery && mediaQuery.matches ? 'dark' : 'light';
+                },
+                applyTheme: (theme) => document.documentElement.setAttribute('data-bs-theme', theme),
+            };
+
+            const themeButtons = document.querySelectorAll('[data-theme-toggle]');
+
+            const syncButtons = (theme) => {
+                themeButtons.forEach((button) => {
+                    const icon = button.querySelector('.theme-toggle-icon');
+                    if (icon) {
+                        icon.textContent = theme === 'dark' ? '🌙' : '🌞';
+                    }
+                    button.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+                    button.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+                });
+            };
+
+            const setTheme = (theme) => {
+                themeUtils.applyTheme(theme);
+                syncButtons(theme);
+            };
+
+            const initialTheme = document.documentElement.getAttribute('data-bs-theme') || themeUtils.getPreferredTheme();
+            setTheme(initialTheme);
+
+            themeButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    const currentTheme = document.documentElement.getAttribute('data-bs-theme');
+                    const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                    setTheme(nextTheme);
+                    themeUtils.setStoredTheme(nextTheme);
+                });
+            });
+
+            if (window.matchMedia) {
+                const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+                mediaQuery.addEventListener('change', (event) => {
+                    if (themeUtils.getStoredTheme()) {
+                        return;
+                    }
+                    const newTheme = event.matches ? 'dark' : 'light';
+                    setTheme(newTheme);
+                });
+            }
+        });
+    </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,31 +4,65 @@
 
 {% block content %}
 {% if user %}
-<h1 class="mb-4">Dashboard</h1>
-<div class="row row-cols-1 row-cols-md-2 g-4">
-    {% set quadrants = [
-        (1, 'Urgent & Important', 'bg-danger text-white'),
-        (2, 'Not Urgent & Important', 'bg-primary text-white'),
-        (3, 'Urgent & Not Important', 'bg-warning text-dark'),
-        (4, 'Not Urgent & Not Important', 'bg-success text-white')
-    ] %}
-    {% for qid, title, header_class in quadrants %}
+<div class="dashboard-header text-center mb-4">
+    <h1 class="dashboard-title mb-2">Dashboard</h1>
+    <p class="text-muted mb-0">Organize your priorities across the Eisenhower Matrix.</p>
+</div>
+{% set quadrants = [
+    (1, 'Urgent & Important', 'bg-danger text-white', 'bg-danger', '⏰'),
+    (2, 'Not Urgent & Important', 'bg-primary text-white', 'bg-primary', '⭐'),
+    (3, 'Urgent & Not Important', 'bg-warning text-dark', 'bg-warning', '⚡'),
+    (4, 'Not Urgent & Not Important', 'bg-success text-white', 'bg-success', '🌱')
+] %}
+<div class="row row-cols-1 row-cols-md-2 g-4 dashboard-grid">
+    {% for qid, title, header_class, progress_class, quadrant_icon in quadrants %}
+    {% set quadrant_tasks = tasks.get(qid, []) %}
+    {% set total_tasks = quadrant_tasks | length %}
+    {% set completed_tasks = quadrant_tasks | selectattr('completed') | list | length %}
+    {% set completion_percentage = (completed_tasks * 100 / total_tasks) | round(0, 'floor') if total_tasks else 0 %}
     <div class="col">
-        <div class="card quadrant-card h-100 shadow-sm">
-            <div class="card-header {{ header_class }}">
-                <h5 class="mb-0">{{ title }}</h5>
+        <div class="card quadrant-card h-100">
+            <div class="card-header {{ header_class }} d-flex align-items-center justify-content-between">
+                <div class="d-flex align-items-center gap-2">
+                    <span class="quadrant-icon" aria-hidden="true">{{ quadrant_icon }}</span>
+                    <h5 class="mb-0">{{ title }} ({{ total_tasks }})</h5>
+                </div>
             </div>
-            <div class="card-body">
-                {% set quadrant_tasks = tasks.get(qid, []) %}
+            <div class="card-body d-flex flex-column gap-3">
+                <div>
+                    <div class="d-flex justify-content-between text-muted small mb-1 progress-meta">
+                        <span>{{ completed_tasks }} of {{ total_tasks }} completed</span>
+                        <span>{{ completion_percentage }}%</span>
+                    </div>
+                    <div class="progress" style="height: 0.5rem;">
+                        <div
+                            class="progress-bar {{ progress_class }}"
+                            role="progressbar"
+                            style="width: {{ completion_percentage }}%"
+                            aria-valuenow="{{ completion_percentage }}"
+                            aria-valuemin="0"
+                            aria-valuemax="100"
+                        ></div>
+                    </div>
+                </div>
                 {% if quadrant_tasks %}
-                <div class="d-flex flex-column gap-3">
+                <div class="task-list d-flex flex-column gap-3 flex-grow-1">
                     {% for task in quadrant_tasks %}
-                    {% set title_classes = 'text-decoration-line-through' if task.completed else '' %}
-                    <div class="card task-card">
+                    {% set title_classes = 'text-decoration-line-through text-muted' if task.completed else '' %}
+                    {% set is_today = task.deadline == today if task.deadline else False %}
+                    {% set is_overdue = task.deadline < today if task.deadline else False %}
+                    <div class="card task-card border-0">
                         <div class="card-body">
-                            <h5 class="card-title {{ title_classes }}">
-                                {{ task.title }}
-                            </h5>
+                            <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+                                <h5 class="card-title mb-0 {{ title_classes }}">{{ task.title }}</h5>
+                                {% if task.deadline %}
+                                    {% if is_overdue %}
+                                    <span class="badge bg-danger fw-semibold">Overdue</span>
+                                    {% elif is_today %}
+                                    <span class="badge bg-warning text-dark fw-semibold">Due Today</span>
+                                    {% endif %}
+                                {% endif %}
+                            </div>
                             {% if task.deadline %}
                             <h6 class="card-subtitle mb-2 text-muted">
                                 <i class="bi bi-calendar-event me-1"></i>
@@ -56,7 +90,11 @@
                     {% endfor %}
                 </div>
                 {% else %}
-                <div class="alert alert-secondary text-center mb-0" role="alert">No tasks yet.</div>
+                <div class="empty-state-card text-center flex-grow-1">
+                    <i class="bi bi-clipboard-check display-5 text-muted"></i>
+                    <h6 class="mt-3 mb-0">No tasks here yet. Add one to get started.</h6>
+                    <span class="visually-hidden">No tasks yet.</span>
+                </div>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- center the dashboard heading without duplicating the welcome message in page content
- apply a dedicated dashboard grid helper so quadrant cards stretch evenly in both responsive breakpoints
- tune custom styles to align the header, remove unused greeting rules, and ensure each quadrant card fills its column height

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9e35e20f4832891bc8f29eb993ef6