### PR TITLE
Simplify OAuth user info retrieval

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,19 +159,6 @@ def authorize():
         abort(400, description="Failed to authorize access token")
 
 
-    # Try to get user info from token
-    user_info = token.get("userinfo")
-    if not user_info:
-        try:
-            resp = google.get("userinfo", token=token)
-            user_info = resp.json() if resp.ok else None
-
-        except Exception as exc:
-            logger.exception("Failed to fetch user info: %s", exc)
-            abort(500, description="Failed to parse user information")
-
-
-    # Try to get user info from token (preferred)
     user_info = token.get("userinfo")
     if not user_info:
         try:
@@ -184,15 +171,6 @@ def authorize():
         except Exception as exc:
             logger.exception("Failed to fetch user info: %s", exc)
             abort(500, description="Failed to parse user information")
-
-    if not user_info or not user_info.get("email"):
-        abort(400, description="Email claim missing from user info")
-
-
-    # Find or create user
-
-    # Find or create user in DB
-
 
     if not user_info or not user_info.get("email"):
         abort(400, description="Email claim missing from user info")


### PR DESCRIPTION
## Summary
- collapse redundant user info fetching branches in the OAuth callback while preserving the mock-friendly fallback
- ensure email validation for the OAuth user info runs once before user creation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbab18d4848328949726a3e3a60ae6