### PR TITLE
Refine navbar markup

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -68,24 +68,7 @@
     {% set current_endpoint = request.endpoint or '' %}
 
     <nav class="navbar navbar-expand-lg bg-white">
-
         <div class="container align-items-center">
-
-
-        <div class="container align-items-center">
-
-
-        <div class="container align-items-center">
-
-
-        <div class="container align-items-center">
-
-        <div class="container">
-
-
-
-
-
             <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">
               {% if user and user.get('name') %}
                 Welcome, {{ user.name }}
@@ -95,24 +78,12 @@
             </a>
 
             {% if user and user.get('name') %}
-            <div class="navbar-title-mobile d-lg-none flex-grow-1 fw-semibold text-center">
-                Schedulist
-            </div>
+                <div class="navbar-title-mobile d-lg-none flex-grow-1 fw-semibold text-center">
+                    Schedulist
+                </div>
             {% endif %}
-            <div class="d-flex align-items-center gap-2 ms-auto d-lg-none mobile-actions">
-
-
-
-
-
-            <a class="navbar-brand fw-bold" href="{{ url_for('index') }}">Schedulist</a>
-
 
             <div class="d-flex align-items-center gap-2 ms-auto d-lg-none">
-
-
-
-
                 <button
                     type="button"
                     class="btn btn-outline-secondary btn-sm theme-toggle"
@@ -135,29 +106,6 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
             </div>
-
-
-
-
-
-
-
-            <button
-                class="navbar-toggler"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#navbarNav"
-                aria-controls="navbarNav"
-                aria-expanded="false"
-                aria-label="Toggle navigation"
-            >
-                <span class="navbar-toggler-icon"></span>
-            </button>
-
-
-
-
-
 
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-lg-auto mb-2 mb-lg-0">


### PR DESCRIPTION
## Summary
- collapse duplicate container wrappers in the navbar
- keep a single set of mobile brand and toggle controls ahead of the collapse
- retain separate theme toggle buttons for mobile and desktop layouts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbab1cea588328a33a0efd6c8c1f87