### PR TITLE
Set navbar brand text to Schedulist

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -70,11 +70,7 @@
     <nav class="navbar navbar-expand-lg bg-white">
         <div class="container align-items-center">
             <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">
-              {% if user and user.get('name') %}
-                Welcome, {{ user.name }}
-              {% else %}
                 Schedulist
-              {% endif %}
             </a>
 
             {% if user and user.get('name') %}


### PR DESCRIPTION
## Summary
- update the navbar brand link so it always displays the literal “Schedulist”

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbafe0849083288db0865b94f93abb