### PR TITLE
Log parsed database URL details

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from datetime import datetime, date
 import logging
 import os
+from urllib.parse import urlparse
 from functools import wraps
 
 from flask import (
@@ -31,6 +32,12 @@ app = Flask(__name__)
 database_url = os.getenv("DATABASE_URL")
 if not database_url:
     raise RuntimeError("DATABASE_URL environment variable not set")
+parsed_url = urlparse(database_url)
+logger.info(
+    "Database connection target host: %s path: %s",
+    parsed_url.hostname,
+    parsed_url.path,
+)
 app.config["SQLALCHEMY_DATABASE_URI"] = database_url
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 secret_key = os.getenv("SECRET_KEY")


### PR DESCRIPTION
## Summary
- parse the configured database URL to access non-sensitive components
- log the database hostname and path while keeping credentials hidden

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68cc350061fc8328b7a9dab58b96309a