### PR TITLE
Render dashboard template on root route

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,7 +111,7 @@ def get_user_task_or_404(task_id: int, current_user: User) -> Task:
 
 @app.route("/")
 def root():
-    return "Schedulist is deployed 🎉"
+    return render_template("dashboard.html")
 
 
 @app.route("/healthz")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+
+{% block title %}Welcome · Schedulist{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <div class="text-center py-5">
+            <h1 class="display-5 fw-semibold mb-3">Welcome to Schedulist</h1>
+            <p class="lead text-muted mb-4">
+                Stay on top of your priorities with the Eisenhower Matrix. Organize tasks, track progress,
+                and focus on what truly matters.
+            </p>
+            <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
+                <a href="{{ url_for('login') }}" class="btn btn-primary btn-lg">
+                    <i class="bi bi-google me-2"></i>Sign in with Google
+                </a>
+                <a href="{{ url_for('index') }}" class="btn btn-outline-secondary btn-lg">
+                    <i class="bi bi-speedometer2 me-2"></i>Go to Dashboard
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- update the root Flask route to render the dashboard template instead of returning a placeholder string
- add a new dashboard template that welcomes users and links to login or the task dashboard

## Testing
- pytest *(fails: RuntimeError: DATABASE_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68cc46eba5248328a329dffdb2f37d45