### PR TITLE
Update OAuth callback route to authorize

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,7 +157,7 @@ def login():
     return google.authorize_redirect(redirect_uri)
 
 
-@app.route("/login/callback")
+@app.route("/authorize")
 def authorize():
     try:
         token = google.authorize_access_token()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,7 @@ def test_authorize_with_email(client, monkeypatch):
         lambda url, token=None: DummyResp({"sub": "abc123", "email": "user@example.com"}),
     )
 
-    response = client.get("/login/callback")
+    response = client.get("/authorize")
     assert response.status_code == 302
     with app.app_context():
         user = db.session.execute(
@@ -50,7 +50,7 @@ def test_authorize_without_email(client, monkeypatch):
         lambda url, token=None: DummyResp({"sub": "abc123"}),
     )
 
-    response = client.get("/login/callback")
+    response = client.get("/authorize")
     assert response.status_code == 400
     assert b"Email claim missing" in response.data
 
@@ -61,7 +61,7 @@ def test_authorize_access_token_error(client, monkeypatch):
 
     monkeypatch.setattr(google, "authorize_access_token", raise_error)
 
-    response = client.get("/login/callback")
+    response = client.get("/authorize")
     assert response.status_code == 400
     assert b"Failed to authorize access token" in response.data
 
@@ -74,6 +74,6 @@ def test_userinfo_fetch_error(client, monkeypatch):
 
     monkeypatch.setattr(google, "get", raise_error)
 
-    response = client.get("/login/callback")
+    response = client.get("/authorize")
     assert response.status_code == 500
     assert b"Failed to parse user information" in response.data

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 def test_root_route(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert b"Server is running" in response.data
+    assert b"Welcome to Schedulist" in response.data
 
 
 def test_login_required(client):


### PR DESCRIPTION
## Summary
- switch the Flask authorize view to use the /authorize route expected by the Google OAuth redirect
- update automated tests to request the new callback path and reflect the current welcome content
- ensure the test environment sets a DATABASE_URL so the app module can be imported during testing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc49f88d0c8328ac4fa5bc51e67e5b