### PR TITLE
Add animated transitions to dashboard UI

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -5,6 +5,19 @@ body {
     color: var(--bs-body-color);
 }
 
+body.page-transition {
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+body.page-transition.is-visible {
+    opacity: 1;
+}
+
+body.page-transition.is-exiting {
+    opacity: 0;
+}
+
 [data-bs-theme="dark"] body {
     background: #121212;
     background-color: #121212;
@@ -126,6 +139,9 @@ main {
     display: flex;
     flex-direction: column;
     height: 100%;
+    animation: cardEntry 0.45s ease both;
+    animation-delay: calc(0.05s * var(--card-index, 0));
+    will-change: opacity, transform;
 }
 
 [data-bs-theme="dark"] .quadrant-card {
@@ -226,6 +242,9 @@ main {
     border-radius: 1rem;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     background-color: var(--bs-card-bg);
+    animation: taskCardEntry 0.4s ease both;
+    animation-delay: calc(0.04s * var(--task-index, 0));
+    will-change: opacity, transform;
 }
 
 .task-card .card-body {
@@ -258,6 +277,7 @@ main {
     align-items: center;
     justify-content: center;
     gap: 0.75rem;
+    animation: emptyStateFadeIn 0.45s ease 0.3s both;
 }
 
 .empty-state-card i {
@@ -289,6 +309,36 @@ main {
     z-index: 1030;
 }
 
+.empty-state-add-btn {
+    animation: emptyStatePulse 3s ease-in-out infinite;
+    transform-origin: center;
+}
+
+.action-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.15s ease;
+    will-change: transform;
+}
+
+.btn:hover .action-icon,
+.btn:focus-visible .action-icon,
+.nav-link:hover .action-icon,
+.nav-link:focus-visible .action-icon,
+.fab:hover .action-icon,
+.fab:focus-visible .action-icon {
+    transform: scale(1.1);
+}
+
+.action-icon.is-popping {
+    animation: iconPop 0.3s ease;
+}
+
+.badge-status {
+    animation: badgeReveal 0.3s ease both;
+}
+
 .fab:hover {
     transform: translateY(-4px);
     box-shadow: 0 1.5rem 3rem rgba(13, 110, 253, 0.35);
@@ -317,5 +367,97 @@ main {
 
     .navbar .nav-link.active::after {
         bottom: -0.2rem;
+    }
+}
+
+@keyframes cardEntry {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.97);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes taskCardEntry {
+    from {
+        opacity: 0;
+        transform: translateY(10px) scale(0.98);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes badgeReveal {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes emptyStateFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes emptyStatePulse {
+    0% {
+        transform: scale(1.05);
+    }
+
+    50% {
+        transform: scale(1);
+    }
+
+    100% {
+        transform: scale(1.05);
+    }
+}
+
+@keyframes iconPop {
+    0% {
+        transform: scale(1);
+    }
+
+    40% {
+        transform: scale(1.18);
+    }
+
+    100% {
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    body.page-transition {
+        transition-duration: 0.01ms !important;
+    }
+
+    .quadrant-card,
+    .task-card,
+    .badge-status,
+    .empty-state-card,
+    .empty-state-add-btn,
+    .action-icon {
+        animation: none !important;
+        transition-duration: 0.01ms !important;
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 page-transition">
     {% set current_endpoint = request.endpoint or '' %}
 
     <nav class="navbar navbar-expand-lg bg-white">
@@ -112,7 +112,7 @@
                             {% if dashboard_active %}aria-current="page"{% endif %}
                             href="{{ url_for('index') }}"
                         >
-                            <i class="bi bi-house-door"></i>
+                            <i class="bi bi-house-door action-icon"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
@@ -123,13 +123,13 @@
                             {% if add_active %}aria-current="page"{% endif %}
                             href="{{ url_for('add_task') }}"
                         >
-                            <i class="bi bi-plus-circle"></i>
+                            <i class="bi bi-plus-circle action-icon"></i>
                             <span>Add Task</span>
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('logout') }}">
-                            <i class="bi bi-box-arrow-right"></i>
+                            <i class="bi bi-box-arrow-right action-icon"></i>
                             <span>Logout</span>
                         </a>
                     </li>
@@ -158,7 +158,7 @@
 
     {% if user %}
         <a class="btn btn-primary fab shadow" href="{{ url_for('add_task') }}" aria-label="Add task">
-            <i class="bi bi-plus-lg"></i>
+            <i class="bi bi-plus-lg action-icon"></i>
         </a>
     {% endif %}
 
@@ -169,6 +169,106 @@
     ></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+            const body = document.body;
+            const transitionDuration = 250;
+
+            if (body.classList.contains('page-transition')) {
+                requestAnimationFrame(() => {
+                    body.classList.add('is-visible');
+                });
+
+                const shouldIgnoreLink = (link, event) => {
+                    if (!link) {
+                        return true;
+                    }
+
+                    const href = link.getAttribute('href');
+                    if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
+                        return true;
+                    }
+
+                    if (link.hasAttribute('data-page-transition-ignore') || link.hasAttribute('data-bs-toggle')) {
+                        return true;
+                    }
+
+                    if (link.target && link.target !== '_self') {
+                        return true;
+                    }
+
+                    if (link.hasAttribute('download')) {
+                        return true;
+                    }
+
+                    if (event) {
+                        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                            return true;
+                        }
+
+                        if (event.button && event.button !== 0) {
+                            return true;
+                        }
+                    }
+
+                    try {
+                        const protocol = link.protocol;
+                        if (
+                            protocol &&
+                            protocol !== window.location.protocol &&
+                            protocol !== 'http:' &&
+                            protocol !== 'https:'
+                        ) {
+                            return true;
+                        }
+
+                        if (link.origin !== window.location.origin) {
+                            return true;
+                        }
+                    } catch (error) {
+                        return true;
+                    }
+
+                    return false;
+                };
+
+                const triggerFadeOut = (callback) => {
+                    if (!body.classList.contains('is-exiting')) {
+                        body.classList.add('is-exiting');
+                    }
+
+                    window.setTimeout(callback, transitionDuration);
+                };
+
+                document.querySelectorAll('a[href]').forEach((link) => {
+                    link.addEventListener('click', (event) => {
+                        if (shouldIgnoreLink(link, event)) {
+                            return;
+                        }
+
+                        event.preventDefault();
+                        triggerFadeOut(() => {
+                            window.location.href = link.href;
+                        });
+                    });
+                });
+
+                document.querySelectorAll('form').forEach((form) => {
+                    form.addEventListener('submit', () => {
+                        if (!body.classList.contains('is-exiting')) {
+                            body.classList.add('is-exiting');
+                        }
+                    });
+                });
+
+                window.addEventListener('pageshow', (event) => {
+                    if (event.persisted) {
+                        body.classList.remove('is-exiting');
+                        requestAnimationFrame(() => {
+                            body.classList.add('is-visible');
+                        });
+                    }
+                });
+            }
+
             const themeUtils = window.schedulistTheme || {
                 getStoredTheme: () => null,
                 setStoredTheme: () => {},
@@ -219,6 +319,32 @@
                     setTheme(newTheme);
                 });
             }
+
+            const activateIconPop = () => {
+                const icons = document.querySelectorAll('.action-icon');
+                icons.forEach((icon) => {
+                    const interactiveParent = icon.closest('a, button');
+                    if (!interactiveParent || interactiveParent.dataset.iconPopBound === 'true') {
+                        return;
+                    }
+
+                    interactiveParent.dataset.iconPopBound = 'true';
+
+                    const handleClick = () => {
+                        icon.classList.remove('is-popping');
+                        // Force reflow to allow re-triggering the animation
+                        void icon.offsetWidth;
+                        icon.classList.add('is-popping');
+                    };
+
+                    interactiveParent.addEventListener('click', handleClick);
+                    icon.addEventListener('animationend', () => {
+                        icon.classList.remove('is-popping');
+                    });
+                });
+            };
+
+            activateIconPop();
         });
     </script>
 </body>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,10 +13,10 @@
             </p>
             <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
                 <a href="{{ url_for('login') }}" class="btn btn-primary btn-lg">
-                    <i class="bi bi-google me-2"></i>Sign in with Google
+                    <i class="bi bi-google me-2 action-icon"></i> Sign in with Google
                 </a>
                 <a href="{{ url_for('index') }}" class="btn btn-outline-secondary btn-lg">
-                    <i class="bi bi-speedometer2 me-2"></i>Go to Dashboard
+                    <i class="bi bi-speedometer2 me-2 action-icon"></i> Go to Dashboard
                 </a>
             </div>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
     {% set completed_tasks = quadrant_tasks | selectattr('completed') | list | length %}
     {% set completion_percentage = (completed_tasks * 100 / total_tasks) | round(0, 'floor') if total_tasks else 0 %}
     <div class="col">
-        <div class="card quadrant-card h-100">
+        <div class="card quadrant-card h-100" style="--card-index: {{ loop.index0 }}">
             <div class="card-header {{ header_class }} d-flex align-items-center justify-content-between">
                 <div class="d-flex align-items-center gap-2">
                     <span class="quadrant-icon" aria-hidden="true">{{ quadrant_icon }}</span>
@@ -57,15 +57,15 @@
                     {% set title_classes = 'text-decoration-line-through text-muted' if task.completed else '' %}
                     {% set is_today = task.deadline == today if task.deadline else False %}
                     {% set is_overdue = task.deadline < today if task.deadline else False %}
-                    <div class="card task-card border-0">
+                    <div class="card task-card border-0" style="--task-index: {{ loop.index0 }}">
                         <div class="card-body">
                             <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
                                 <h5 class="card-title mb-0 {{ title_classes }}">{{ task.title }}</h5>
                                 {% if task.deadline %}
                                     {% if is_overdue %}
-                                    <span class="badge bg-danger fw-semibold">Overdue</span>
+                                    <span class="badge bg-danger fw-semibold badge-status">Overdue</span>
                                     {% elif is_today %}
-                                    <span class="badge bg-warning text-dark fw-semibold">Due Today</span>
+                                    <span class="badge bg-warning text-dark fw-semibold badge-status">Due Today</span>
                                     {% endif %}
                                 {% endif %}
                             </div>
@@ -80,15 +80,15 @@
                             {% endif %}
                             <div class="btn-group btn-group-sm" role="group">
                                 <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-outline-secondary">
-                                    <i class="bi bi-pencil"></i> Edit
+                                    <i class="bi bi-pencil me-1 action-icon"></i> Edit
                                 </a>
                                 <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-outline-danger">
-                                    <i class="bi bi-trash"></i> Delete
+                                    <i class="bi bi-trash me-1 action-icon"></i> Delete
                                 </a>
                                 {% set action_icon = 'bi-arrow-counterclockwise' if task.completed else 'bi-check' %}
                                 {% set action_label = 'Undo' if task.completed else 'Done' %}
                                 <a href="{{ url_for('toggle_task', task_id=task.id) }}" class="btn btn-outline-success">
-                                    <i class="bi {{ action_icon }}"></i> {{ action_label }}
+                                    <i class="bi {{ action_icon }} me-1 action-icon"></i> {{ action_label }}
                                 </a>
                             </div>
                         </div>
@@ -101,8 +101,8 @@
                         <i class="bi bi-clipboard-check display-5 text-muted"></i>
                         <h6 class="mt-3">No tasks here yet. Add one to get started.</h6>
                         <span class="visually-hidden">No tasks yet.</span>
-                        <a class="btn btn-outline-primary btn-sm mt-2" href="{{ url_for('add_task') }}">
-                            <i class="bi bi-plus-circle me-1"></i>
+                        <a class="btn btn-outline-primary btn-sm mt-2 empty-state-add-btn" href="{{ url_for('add_task') }}">
+                            <i class="bi bi-plus-circle me-1 action-icon"></i>
                             Add Task
                         </a>
                     </div>
@@ -115,7 +115,7 @@
 </div>
 
 <a class="btn btn-primary fab shadow" href="{{ url_for('add_task') }}" aria-label="Add task">
-    <i class="bi bi-plus-lg"></i>
+    <i class="bi bi-plus-lg action-icon"></i>
 </a>
 {% else %}
 <div class="text-center">


### PR DESCRIPTION
## Summary
- add fade-in/out page transitions and icon feedback handlers to the shared layout
- introduce CSS keyframes for task cards, badges, and empty states to animate on load
- tag dashboard buttons with animation classes so hover and click effects play consistently

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce6e0b1f348328b8b37afa7f16ac42