### PR TITLE
Add dashboard background override

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -5,6 +5,12 @@ body {
     color: var(--bs-body-color);
 }
 
+body.dashboard-bg {
+    background: #281856;
+    background-color: #281856;
+    color: #f5f3ff;
+}
+
 body.page-transition {
     opacity: 0;
     transition: opacity 0.25s ease;

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
 </head>
-<body class="d-flex flex-column min-vh-100 page-transition">
+<body class="d-flex flex-column min-vh-100 page-transition{% block body_class %}{% endblock %}">
     {% set current_endpoint = request.endpoint or '' %}
 
     <nav class="navbar navbar-expand-lg bg-white">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,6 +2,8 @@
 
 {% block title %}Welcome · Schedulist{% endblock %}
 
+{% block body_class %} dashboard-bg{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-lg-8">


### PR DESCRIPTION
## Summary
- allow pages to augment the body element with template-specific classes
- add a dashboard-specific body class that provides a custom background color
- supply CSS for the dashboard body class to use a solid, high-contrast background

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce750a02948328b9939f5fc4b771e0