### PR TITLE
Add dashboard-specific body class styling

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -6,9 +6,9 @@ body {
 }
 
 body.dashboard-bg {
-    background: #281856;
-    background-color: #281856;
-    color: #f5f3ff;
+    background: none;
+    background-color: #8329AC;
+    color: #ffffff;
 }
 
 body.page-transition {
@@ -33,6 +33,12 @@ body.page-transition.is-exiting {
 html[data-bs-theme="dark"] body {
     background: linear-gradient(180deg, #0f172a 0%, #111827 40%, #0b1120 100%);
     color: #e0e0e0;
+}
+
+html[data-bs-theme="dark"] body.dashboard-bg {
+    background: none;
+    background-color: #8329AC;
+    color: #ffffff;
 }
 
 main {

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
 </head>
-<body class="d-flex flex-column min-vh-100 page-transition{% block body_class %}{% endblock %}">
+<body
+    class="d-flex flex-column min-vh-100 page-transition{% block body_class %}{% endblock body_class %}"
+>
     {% set current_endpoint = request.endpoint or '' %}
 
     <nav class="navbar navbar-expand-lg bg-white">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,7 +2,7 @@
 
 {% block title %}Welcome · Schedulist{% endblock %}
 
-{% block body_class %} dashboard-bg{% endblock %}
+{% block body_class %} dashboard-bg{% endblock body_class %}
 
 {% block content %}
 <div class="row justify-content-center">


### PR DESCRIPTION
## Summary
- allow templates to inject custom body classes from the base layout
- apply a dashboard-specific body class and styling with an accessible solid background colour
- ensure the dashboard background override also applies when the dark theme is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce774354688328bfbed0dd5ce02058