### PR TITLE
Restore dashboard background colors

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -6,9 +6,9 @@ body {
 }
 
 body.dashboard-bg {
-    background: none;
-    background-color: #8329AC;
-    color: #ffffff;
+    background: #281856;
+    background-color: #281856;
+    color: #f5f3ff;
 }
 
 body.page-transition {
@@ -36,9 +36,9 @@ html[data-bs-theme="dark"] body {
 }
 
 html[data-bs-theme="dark"] body.dashboard-bg {
-    background: none;
-    background-color: #8329AC;
-    color: #ffffff;
+    background: #281856;
+    background-color: #281856;
+    color: #f5f3ff;
 }
 
 main {


### PR DESCRIPTION
## Summary
- restore the dashboard-specific background and text colors to the original palette
- ensure the dark theme uses the same restored colors for consistency

## Testing
- DATABASE_URL=sqlite:///tmp.db SECRET_KEY=dev GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy pytest
- Manual verification of dashboard color in light and dark themes

------
https://chatgpt.com/codex/tasks/task_e_68ce7de8dc9c8328bbaafb1fe1fe12a5