### PR TITLE
Add dashboard CTA screenshot image

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,6 +21,11 @@
                     <i class="bi bi-speedometer2 me-2 action-icon"></i> Go to Dashboard
                 </a>
             </div>
+            <img
+                src="{{ url_for('static', filename='assets/screenshots/lpg.jpg') }}"
+                alt="Schedulist in action"
+                class="img-fluid mt-4"
+            >
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- display the CTA screenshot below the dashboard sign-in buttons by adding the static image to the template

## Testing
- env DATABASE_URL=sqlite:///test.db SECRET_KEY=test GOOGLE_CLIENT_ID=d GOOGLE_CLIENT_SECRET=d python - <<'PY'
from app import app
client = app.test_client()
resp = client.get('/')
resp.raise_for_status = lambda: None
body = resp.get_data(as_text=True)
if "assets/screenshots/lpg.jpg" not in body:
    raise SystemExit('screenshot image not found in dashboard output')
print('dashboard route includes screenshot image tag')
PY

------
https://chatgpt.com/codex/tasks/task_e_68ce7ec879f883288429a94f3728d79d