### PR TITLE
Style dashboard hero image

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -11,6 +11,24 @@ body.dashboard-bg {
     color: #f5f3ff;
 }
 
+.dashboard-hero-image {
+    display: block;
+    width: 100%;
+    margin: 0 auto;
+    padding: 0.75rem;
+    border-radius: 1.5rem;
+    box-sizing: border-box;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
+    box-shadow: 0 1.75rem 3.5rem rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.55);
+}
+
+html[data-bs-theme="dark"] .dashboard-hero-image {
+    background: linear-gradient(135deg, rgba(61, 38, 120, 0.75), rgba(88, 70, 146, 0.65));
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 1.75rem 3.5rem rgba(2, 6, 23, 0.65);
+}
+
 body.page-transition {
     opacity: 0;
     transition: opacity 0.25s ease;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -24,7 +24,7 @@
             <img
                 src="{{ url_for('static', filename='assets/screenshots/lpg.jpg') }}"
                 alt="Schedulist in action"
-                class="img-fluid mt-4"
+                class="img-fluid mt-4 dashboard-hero-image"
             >
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a dedicated utility class to the dashboard hero image for custom styling
- style the new hero image class with a lifted card look, including drop shadow and theme-aware background treatment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce8a6a24348328be4380474e250c05