### PR TITLE
Fix dashboard hero image path

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -22,7 +22,7 @@
                 </a>
             </div>
             <img
-                src="{{ url_for('static', filename='assets/screenshots/dashboard-2.png') }}"
+                src="{{ url_for('static', filename='assets/screenshots/dashboard-2.jpg') }}"
                 alt="Schedulist in action"
                 class="img-fluid mt-4 dashboard-hero-image"
             >


### PR DESCRIPTION
## Summary
- update the dashboard hero image to load the existing JPG asset

## Testing
- `flask run --host=0.0.0.0 --port=5000`
- `curl -I http://127.0.0.1:5000/static/assets/screenshots/dashboard-2.jpg`


------
https://chatgpt.com/codex/tasks/task_e_68d09b4de1808328a9de7f664bf13f07