### PR TITLE
Fix dashboard screenshot extension

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -22,7 +22,7 @@
                 </a>
             </div>
             <img
-                src="{{ url_for('static', filename='assets/screenshots/dashboard-2.png') }}"
+                src="{{ url_for('static', filename='assets/screenshots/dashboard-2.jpg') }}"
                 alt="Schedulist in action"
                 class="img-fluid mt-4 dashboard-hero-image"
             >


### PR DESCRIPTION
## Summary
- correct the dashboard screenshot image filename extension used in the dashboard template so the asset loads properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0b4eaf1088328894fe4a4e583aa62